### PR TITLE
Fix/wp-248-button-rendering-issue

### DIFF
--- a/src/components/styled/ChatComponents.tsx
+++ b/src/components/styled/ChatComponents.tsx
@@ -6,6 +6,26 @@ export const ChatWidget = styled.div`
   background-color: white;
   border: 1px solid #e5e7eb;
   min-height: 0;
+
+  /* Scoped CSS reset to prevent host page style leakage */
+  & button,
+  & input,
+  & textarea,
+  & select {
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: none;
+    box-sizing: border-box;
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: normal;
+    line-height: normal;
+    color: inherit;
+    text-shadow: none;
+    -webkit-appearance: none;
+    appearance: none;
+  }
   
   /* Try both media query approaches */
   @media (prefers-color-scheme: dark) {
@@ -152,6 +172,9 @@ export const SendButton = styled.button`
   height: 32px;
   min-width: 32px;
   min-height: 32px;
+  padding: 0;
+  box-sizing: border-box;
+  line-height: normal;
   background: transparent;
   border: 2px solid #3b82f6;
   border-radius: 50%;
@@ -238,6 +261,8 @@ export const FloatingButton = styled.button<{ $position?: string; $primaryColor?
   z-index: 50;
   height: 48px;
   padding: 0 16px;
+  box-sizing: border-box;
+  line-height: normal;
   background: ${props => {
     if (props.$primaryColor) {
       const darker = darkenColor(props.$primaryColor, 0.1)
@@ -363,6 +388,9 @@ export const ChatHeader = styled.div<{ primaryColor?: string }>`
 export const CloseButton = styled.button`
   width: 24px;
   height: 24px;
+  padding: 0;
+  box-sizing: border-box;
+  line-height: normal;
   background: transparent;
   border: none;
   color: white;
@@ -622,6 +650,8 @@ export const WelcomeQuestionsContainer = styled.div`
 export const QuestionButton = styled.button<{ $primaryColor?: string }>`
   width: 100%;
   padding: 12px 16px;
+  box-sizing: border-box;
+  line-height: normal;
   text-align: left;
   border: 1px solid #e5e7eb;
   border-radius: 8px;

--- a/static/wordpress-demo.html
+++ b/static/wordpress-demo.html
@@ -1,34 +1,101 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ordify Chat Widget – WordPress / script-tag test</title>
   <style>
-    body { font-family: system-ui, sans-serif; max-width: 640px; margin: 2rem auto; padding: 0 1rem; }
-    h1 { font-size: 1.25rem; }
-    .note { background: #f0f4ff; border: 1px solid #b8d4ff; border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 1.5rem; font-size: 0.875rem; }
-    .note strong { display: block; margin-bottom: 0.25rem; }
-    .config { margin-bottom: 1.5rem; padding: 1.25rem; border: 2px solid #e0e0e0; border-radius: 8px; background: #fff; }
-    .config h2 { margin-top: 0; font-size: 1.1rem; }
-    .config-desc { color: #666; font-size: 0.875rem; margin-bottom: 1rem; }
-    .config label { display: block; margin-bottom: 0.25rem; font-weight: 600; }
-    .config input { width: 100%; padding: 0.5rem 0.75rem; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; }
-    .config .field { margin-bottom: 1rem; }
-    .config button { padding: 0.5rem 1rem; background: #2563eb; color: #fff; border: none; border-radius: 4px; font-weight: 600; cursor: pointer; }
-    .config button:hover { background: #1d4ed8; }
+    body {
+      font-family: system-ui, sans-serif;
+      max-width: 640px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+    }
+
+    h1 {
+      font-size: 1.25rem;
+    }
+
+    .note {
+      background: #f0f4ff;
+      border: 1px solid #b8d4ff;
+      border-radius: 6px;
+      padding: 0.75rem 1rem;
+      margin-bottom: 1.5rem;
+      font-size: 0.875rem;
+    }
+
+    .note strong {
+      display: block;
+      margin-bottom: 0.25rem;
+    }
+
+    .config {
+      margin-bottom: 1.5rem;
+      padding: 1.25rem;
+      border: 2px solid #e0e0e0;
+      border-radius: 8px;
+      background: #fff;
+    }
+
+    .config h2 {
+      margin-top: 0;
+      font-size: 1.1rem;
+    }
+
+    .config-desc {
+      color: #666;
+      font-size: 0.875rem;
+      margin-bottom: 1rem;
+    }
+
+    .config label {
+      display: block;
+      margin-bottom: 0.25rem;
+      font-weight: 600;
+    }
+
+    .config input {
+      width: 100%;
+      padding: 0.5rem 0.75rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      box-sizing: border-box;
+    }
+
+    .config .field {
+      margin-bottom: 1rem;
+    }
+
+    .config button {
+      padding: 0.5rem 1rem;
+      background: #2563eb;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+
+    .config button:hover {
+      background: #1d4ed8;
+    }
   </style>
 </head>
+
 <body>
   <h1>Ordify Chat Widget – WordPress / script-tag test</h1>
   <p class="note">
     <strong>How to run this page</strong>
-    From the repo root run <code>npm run build</code>, then serve the repo (e.g. <code>npx serve .</code>) and open <code>/static/wordpress-demo.html</code>.
+    From the repo root run <code>npm run build</code>, then serve the repo (e.g. <code>npx serve .</code>) and open
+    <code>/static/wordpress-demo.html</code>.
   </p>
 
   <div class="config">
     <h2>Configuration</h2>
-    <p class="config-desc">Enter your Ordify credentials to test the chat widget. Your configuration will be saved locally in your browser.</p>
+    <p class="config-desc">Enter your Ordify credentials to test the chat widget. Your configuration will be saved
+      locally in your browser.</p>
     <div class="field">
       <label for="agent-id">Agent ID *</label>
       <input id="agent-id" type="text" placeholder="Enter your Agent ID" />
@@ -44,7 +111,8 @@
     <button type="button" id="apply-btn">Apply and start chat</button>
   </div>
 
-  <p>If the widget is configured correctly, a chat button appears in the corner. This page simulates how the widget is loaded on WordPress or any non-React site.</p>
+  <p>If the widget is configured correctly, a chat button appears in the corner. This page simulates how the widget is
+    loaded on WordPress or any non-React site.</p>
 
   <script src="../dist/ordify-chat-widget.standalone.js"></script>
   <script>
@@ -68,7 +136,7 @@
           document.getElementById('api-base-url').value = c.apiBaseUrl || 'https://r.ordify.ai';
           return c;
         }
-      } catch (e) {}
+      } catch (e) { }
       return null;
     }
 
@@ -108,4 +176,5 @@
     document.getElementById('apply-btn').addEventListener('click', onApply);
   </script>
 </body>
+
 </html>


### PR DESCRIPTION
## Summary
This PR fixes the rendering issue of the send button in the chat widget when deployed in WordPress themes like Twenty Seventeen.

The fix includes:
- A scoped CSS reset in the `ChatWidget` root component to prevent theme styles from leaking into the widget's buttons and inputs.
- Hardening of individual button components (`SendButton`, `CloseButton`, `FloatingButton`, `QuestionButton`) with explicit `padding`, `box-sizing`, and `line-height` resets.
