### PR TITLE
refactor: update API key usage to publishable key in documentation an…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ Before integrating the chat widget, ensure you have:
 
 - **Node.js**: 18.0.0 or higher
 - **npm**: 9.0.0 or higher  
-- **API Key**: Available in your Ordify dashboard (Account → Settings → API)
+- **Publishable Key (`pk_live_...`)**: Create in Ordify dashboard (Settings → Publishable Keys)
 - **Agent ID**: Found in your agent configuration panel within the Ordify application
 - **React Application**: Compatible with React 18+ and modern build tools
 
 
 > **🚀 Try it live!** Visit [app.ordify.ai/widget-demo](https://app.ordify.ai/widget-demo) to see all chat modes in action.
+
+> **Production Security:** Use `publishableKey`/`data-ordify-publishable-key` with allowed origins. Keep account `apiKey` for server-side use only.
 
 ## ✨ Features
 
@@ -65,7 +67,7 @@ function App() {
   return (
     <OrdifyChat
       agentId="your-agent-id"
-      apiKey="your-api-key"
+      publishableKey="pk_live_..."
       apiBaseUrl="https://r.ordify.ai"
       chatName="AI Assistant"
       buttonText="Chat with us"
@@ -107,7 +109,7 @@ Load the standalone script from a CDN (use a version number to pin; replace `1.0
 <script>
   OrdifyChatWidget.mount(null, {
     agentId: "your-agent-id",
-    apiKey: "your-api-key",
+    publishableKey: "pk_live_...",
     apiBaseUrl: "https://r.ordify.ai",
     mode: "floating",
     position: "bottom-right",
@@ -123,7 +125,7 @@ Load the standalone script from a CDN (use a version number to pin; replace `1.0
 <script>
   OrdifyChatWidget.mount(null, {
     agentId: "your-agent-id",
-    apiKey: "your-api-key",
+    publishableKey: "pk_live_...",
     apiBaseUrl: "https://r.ordify.ai",
     buttonText: "Chat with us"
   });
@@ -142,7 +144,7 @@ Add a single script tag with `data-ordify-widget` and the required/optional data
   src="https://unpkg.com/ordify-chat-widget@1.0.38/dist/ordify-chat-widget.standalone.js"
   data-ordify-widget
   data-ordify-agent-id="your-agent-id"
-  data-ordify-api-key="your-api-key"
+  data-ordify-publishable-key="pk_live_..."
   data-ordify-api-base-url="https://r.ordify.ai"
   data-ordify-button-text="Chat with us"
   data-ordify-chat-name="AI Assistant"
@@ -150,12 +152,13 @@ Add a single script tag with `data-ordify-widget` and the required/optional data
 ></script>
 ```
 
-**Supported data attributes (all optional except agent-id and api-key):**
+**Supported data attributes (all optional except agent-id and one credential):**
 
 | Attribute | Description |
 |-----------|-------------|
 | `data-ordify-agent-id` | **Required.** Your Ordify agent ID. |
-| `data-ordify-api-key` | **Required.** Your API key. |
+| `data-ordify-publishable-key` | Recommended. Your publishable key (`pk_live_...`) for browser embeds. |
+| `data-ordify-api-key` | Legacy/deprecated for browser embeds. Prefer publishable key. |
 | `data-ordify-api-base-url` | API base URL (default: `https://r.ordify.ai`). |
 | `data-ordify-button-text` | Floating button label. |
 | `data-ordify-chat-name` | Chat header title. |
@@ -176,10 +179,10 @@ Add a single script tag with `data-ordify-widget` and the required/optional data
 
 **Where to put your API key and Agent ID**
 
-The widget does **not** use a separate config file. You put the Agent ID and API key in the same place as the script:
+The widget does **not** use a separate config file. You put the Agent ID and credential in the same place as the script:
 
-- **Option 1 (script + mount):** In the inline snippet, replace `"your-agent-id"` and `"your-api-key"` with your real values. That snippet lives wherever you add it (theme header/footer or a plugin’s “custom code” field).
-- **Option 2 (data attributes):** In the script tag, set `data-ordify-agent-id="your-agent-id"` and `data-ordify-api-key="your-api-key"` (and optionally `data-ordify-api-base-url`). Again, that tag is added via theme or plugin.
+- **Option 1 (script + mount):** In the inline snippet, replace `"your-agent-id"` and `"pk_live_..."` with your real values.
+- **Option 2 (data attributes):** In the script tag, set `data-ordify-agent-id="your-agent-id"` and `data-ordify-publishable-key="pk_live_..."` (and optionally `data-ordify-api-base-url`).
 
 So the “config” is the snippet or script tag you paste; the credentials are inside it.
 
@@ -197,7 +200,7 @@ So the “config” is the snippet or script tag you paste; the credentials are 
 ```tsx
 <OrdifyChat
   agentId="your-agent-id"
-  apiKey="your-api-key"
+  publishableKey="pk_live_..."
   mode="floating"
   position="bottom-right"
   buttonText="AI Chat"
@@ -208,7 +211,7 @@ So the “config” is the snippet or script tag you paste; the credentials are 
 ```tsx
 <OrdifyChat
   agentId="your-agent-id"
-  apiKey="your-api-key"
+  publishableKey="pk_live_..."
   mode="embedded"
   height="500px"
   chatName="Support Assistant"
@@ -223,7 +226,8 @@ So the “config” is the snippet or script tag you paste; the credentials are 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `agentId` | string | - | **Required** - Your Ordify agent ID |
-| `apiKey` | string | - | **Required** - Your API key |
+| `publishableKey` | string | - | Recommended for browser embeds (`pk_live_...`) |
+| `apiKey` | string | - | Legacy browser credential (supported for migration) |
 | `apiBaseUrl` | string | - | **Required** - API endpoint URL |
 | `chatName` | string | "Chat Assistant" | Title text in chat header |
 | `buttonText` | string | "AI Chat" | Text on floating button |

--- a/examples/integration/README.md
+++ b/examples/integration/README.md
@@ -21,7 +21,7 @@ This directory contains code snippets showing how to integrate the Ordify Chat W
 
 3. **Replace the configuration** with your actual values:
    - `agentId` - Your Ordify agent ID
-   - `apiKey` - Your API key
+   - `publishableKey` - Your publishable key (`pk_live_...`)
    - `apiBaseUrl` - API endpoint URL (defaults to https://r.ordify.ai)
 
 4. **Customize** the chat appearance and behavior as needed
@@ -42,7 +42,7 @@ For production, use environment variables:
 ```bash
 # .env.local
 NEXT_PUBLIC_ORDIFY_AGENT_ID=your-agent-id
-NEXT_PUBLIC_ORDIFY_API_KEY=your-api-key
+NEXT_PUBLIC_ORDIFY_PUBLISHABLE_KEY=pk_live_...
 NEXT_PUBLIC_ORDIFY_API_URL=https://r.ordify.ai
 ```
 

--- a/examples/integration/landing-page.tsx
+++ b/examples/integration/landing-page.tsx
@@ -26,7 +26,7 @@ export default function HomePage() {
       {/* Add floating chat widget */}
       <OrdifyChat
         agentId="your-agent-id"
-        apiKey="your-api-key"
+        publishableKey="pk_live_..."
         apiBaseUrl="https://r.ordify.ai"
         mode="floating"
         position="bottom-right"

--- a/examples/integration/nextjs-app-router.tsx
+++ b/examples/integration/nextjs-app-router.tsx
@@ -10,7 +10,7 @@ export default function ChatPage() {
       <h1 className="text-2xl font-bold mb-4">Chat with AI</h1>
       <OrdifyChat 
         agentId={process.env.NEXT_PUBLIC_ORDIFY_AGENT_ID!}
-        apiKey={process.env.NEXT_PUBLIC_ORDIFY_API_KEY!}
+        publishableKey={process.env.NEXT_PUBLIC_ORDIFY_PUBLISHABLE_KEY!}
         apiBaseUrl="https://r.ordify.ai"
         mode="embedded"
         height="500px"

--- a/examples/integration/nextjs-pages-router.tsx
+++ b/examples/integration/nextjs-pages-router.tsx
@@ -8,7 +8,7 @@ export default function ChatPage() {
       <h1 className="text-2xl font-bold mb-4">Chat with AI</h1>
       <OrdifyChat 
         agentId={process.env.NEXT_PUBLIC_ORDIFY_AGENT_ID!}
-        apiKey={process.env.NEXT_PUBLIC_ORDIFY_API_KEY!}
+        publishableKey={process.env.NEXT_PUBLIC_ORDIFY_PUBLISHABLE_KEY!}
         apiBaseUrl="https://r.ordify.ai"
         mode="embedded"
         height="500px"

--- a/examples/integration/react-component.tsx
+++ b/examples/integration/react-component.tsx
@@ -6,7 +6,7 @@ export function ChatWidget() {
   return (
     <OrdifyChat
       agentId="your-agent-id"
-      apiKey="your-api-key"
+      publishableKey="pk_live_..."
       apiBaseUrl="https://api.ordify.ai"
       mode="floating"
       position="bottom-right"

--- a/examples/integration/support-page.tsx
+++ b/examples/integration/support-page.tsx
@@ -34,7 +34,7 @@ export default function SupportPage() {
             
             <OrdifyChat
               agentId="your-agent-id"
-              apiKey="your-api-key"
+              publishableKey="pk_live_..."
               apiBaseUrl="https://r.ordify.ai"
               mode="embedded"
               height="400px"

--- a/src/demo.tsx
+++ b/src/demo.tsx
@@ -7,6 +7,7 @@ const SESSION_STORAGE_KEY = 'ordify-demo-sessions'
 
 function DemoApp() {
   const [agentId, setAgentId] = useState("")
+  const [publishableKey, setPublishableKey] = useState("")
   const [apiKey, setApiKey] = useState("")
   const [apiBaseUrl, setApiBaseUrl] = useState("http://localhost:5001")
   const [chatName, setChatName] = useState("Chat Assistant")
@@ -27,6 +28,7 @@ function DemoApp() {
       try {
         const config = JSON.parse(saved)
         setAgentId(config.agentId || "")
+        setPublishableKey(config.publishableKey || "")
         setApiKey(config.apiKey || "")
         setApiBaseUrl(config.apiBaseUrl || "http://localhost:5001")
         setChatName(config.chatName || "Chat Assistant")
@@ -58,6 +60,7 @@ function DemoApp() {
   useEffect(() => {
     const config = {
       agentId,
+      publishableKey,
       apiKey,
       apiBaseUrl,
       chatName,
@@ -71,7 +74,7 @@ function DemoApp() {
       position
     }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(config))
-  }, [agentId, apiKey, apiBaseUrl, chatName, buttonText, primaryColor, agentImage, quickQuestions, welcomeMessage, welcomeImage, theme, position])
+  }, [agentId, publishableKey, apiKey, apiBaseUrl, chatName, buttonText, primaryColor, agentImage, quickQuestions, welcomeMessage, welcomeImage, theme, position])
 
   // State for dynamic testing
   const [initialMessage, setInitialMessage] = useState("Hi")
@@ -192,7 +195,25 @@ function DemoApp() {
 
           <div>
             <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>
-              API Key *
+              Publishable Key (recommended)
+            </label>
+            <input
+              type="password"
+              value={publishableKey}
+              onChange={(e) => setPublishableKey(e.target.value)}
+              style={{
+                width: '100%',
+                padding: '8px',
+                border: '1px solid #ccc',
+                borderRadius: '4px'
+              }}
+              placeholder="Enter your pk_live_..."
+            />
+          </div>
+
+          <div>
+            <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>
+              API Key (legacy)
             </label>
             <input
               type="password"
@@ -625,6 +646,7 @@ function DemoApp() {
           <OrdifyChat
             key={`floating-${testKey}`}
             agentId={agentId}
+            publishableKey={publishableKey}
             apiKey={apiKey}
             apiBaseUrl={apiBaseUrl}
             mode="floating"
@@ -788,6 +810,7 @@ function DemoApp() {
               <OrdifyChat
                 key={`embedded-${testKey}`}
                 agentId={agentId}
+                publishableKey={publishableKey}
                 apiKey={apiKey}
                 apiBaseUrl={apiBaseUrl}
                 mode="embedded"

--- a/src/hooks/useOrdifyChat.ts
+++ b/src/hooks/useOrdifyChat.ts
@@ -22,6 +22,7 @@ export function useOrdifyChat(config: OrdifyConfig): UseOrdifyChatReturn {
   // Initialize API client
   if (!apiClientRef.current) {
     apiClientRef.current = new OrdifyApiClient({
+      publishableKey: config.publishableKey,
       apiKey: config.apiKey,
       apiBaseUrl: config.apiBaseUrl || 'https://api.ordify.ai',
       agentId: config.agentId

--- a/src/hooks/useOrdifyChat.ts
+++ b/src/hooks/useOrdifyChat.ts
@@ -15,9 +15,17 @@ export function useOrdifyChat(config: OrdifyConfig): UseOrdifyChatReturn {
   const [hasSessionStarted, setHasSessionStarted] = useState(false)
 
   const apiClientRef = useRef<OrdifyApiClient | null>(null)
+  const credFingerprintRef = useRef<string>('')
   const initialMessageSentRef = useRef(false)
   const historyLoadedRef = useRef(false)
   const isStreamingRef = useRef(false)
+
+  // Reset API client when credentials or endpoint change so stale clients are never used
+  const credFingerprint = `${config.publishableKey ?? ''}|${config.apiKey ?? ''}|${config.apiBaseUrl ?? ''}|${config.agentId}`
+  if (credFingerprintRef.current !== credFingerprint) {
+    apiClientRef.current = null
+    credFingerprintRef.current = credFingerprint
+  }
 
   // Initialize API client
   if (!apiClientRef.current) {

--- a/src/hooks/useOrdifyConfig.ts
+++ b/src/hooks/useOrdifyConfig.ts
@@ -5,6 +5,7 @@ export function useOrdifyConfig(config: OrdifyConfig) {
   return useMemo(() => {
     // Get configuration from props or environment variables
     const agentId = config.agentId || process.env.ORDIFY_AGENT_ID
+    const publishableKey = config.publishableKey || process.env.ORDIFY_PUBLISHABLE_KEY
     const apiKey = config.apiKey || process.env.ORDIFY_API_KEY
     const apiBaseUrl = config.apiBaseUrl || process.env.ORDIFY_API_BASE_URL || 'https://r.ordify.ai'
 
@@ -12,12 +13,15 @@ export function useOrdifyConfig(config: OrdifyConfig) {
       throw new Error('Ordify agent ID is required. Provide agentId prop or set ORDIFY_AGENT_ID environment variable.')
     }
 
-    if (!apiKey) {
-      throw new Error('Ordify API key is required. Provide apiKey prop or set ORDIFY_API_KEY environment variable.')
+    if (!publishableKey && !apiKey) {
+      throw new Error(
+        'Ordify credentials are required. Provide publishableKey (recommended) or apiKey.'
+      )
     }
 
     return {
       agentId,
+      publishableKey,
       apiKey,
       apiBaseUrl,
       mode: config.mode || 'floating',

--- a/src/standalone.tsx
+++ b/src/standalone.tsx
@@ -10,6 +10,7 @@ function getDataConfig(script: HTMLScriptElement): Partial<OrdifyConfig> {
   const get = (key: string) => script.getAttribute(DATA_PREFIX + key)
   const config: Partial<OrdifyConfig> = {
     agentId: get('agent-id') ?? undefined,
+    publishableKey: get('publishable-key') ?? undefined,
     apiKey: get('api-key') ?? undefined,
     apiBaseUrl: get('api-base-url') ?? 'https://r.ordify.ai',
     mode: (get('mode') as OrdifyConfig['mode']) ?? 'floating',
@@ -41,9 +42,15 @@ function getDataConfig(script: HTMLScriptElement): Partial<OrdifyConfig> {
 }
 
 function mount(container: HTMLElement | null | undefined, config: OrdifyConfig): void {
-  if (!config.agentId || !config.apiKey) {
-    console.error('Ordify Chat Widget: agentId and apiKey are required.')
+  const hasCredential = Boolean(config.publishableKey || config.apiKey)
+  if (!config.agentId || !hasCredential) {
+    console.error('Ordify Chat Widget: agentId and publishableKey (or legacy apiKey) are required.')
     return
+  }
+  if (!config.publishableKey && config.apiKey) {
+    console.warn(
+      '[Ordify] Using legacy data-ordify-api-key. For production embeds, use data-ordify-publishable-key.'
+    )
   }
   const rootEl = container ?? (() => {
     const div = document.createElement('div')
@@ -59,8 +66,10 @@ function autoMount(): void {
   const scripts = document.querySelectorAll<HTMLScriptElement>(SCRIPT_SELECTOR)
   scripts.forEach((script) => {
     const config = getDataConfig(script)
-    if (!config.agentId || !config.apiKey) {
-      console.warn('Ordify Chat Widget: script tag missing data-ordify-agent-id or data-ordify-api-key. Skip auto-mount.')
+    if (!config.agentId || (!config.publishableKey && !config.apiKey)) {
+      console.warn(
+        'Ordify Chat Widget: script tag missing data-ordify-agent-id or credentials (data-ordify-publishable-key / data-ordify-api-key). Skip auto-mount.'
+      )
       return
     }
     const containerId = script.getAttribute(DATA_PREFIX + 'container-id')

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,7 +44,8 @@ export interface Agent {
 
 export interface OrdifyConfig {
   agentId: string
-  apiKey: string
+  apiKey?: string
+  publishableKey?: string
   apiBaseUrl?: string
   mode?: 'floating' | 'embedded'
   position?: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'
@@ -116,7 +117,8 @@ export interface ApiError {
 }
 
 export interface OrdifyApiClientConfig {
-  apiKey: string
+  apiKey?: string
+  publishableKey?: string
   apiBaseUrl: string
   agentId: string
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,15 +1,56 @@
-import { Agent, ApiError, ChatRequest, Message, OrdifyApiClientConfig, Session, StreamingResponse } from '@/types'
+import { ApiError, ChatRequest, Message, OrdifyApiClientConfig, Session, StreamingResponse } from '@/types'
 
 export class OrdifyApiClient {
   private config: OrdifyApiClientConfig
+  private warnedLegacyApiKey = false
 
   constructor(config: OrdifyApiClientConfig) {
     this.config = config
+    if (!this.config.publishableKey && !this.config.apiKey) {
+      throw new Error('Either publishableKey or apiKey is required.')
+    }
+    if (this.config.publishableKey && this.config.apiKey) {
+      console.warn('[Ordify] Both publishableKey and apiKey provided. publishableKey will be used.')
+    }
+  }
+
+  private usePublishableKey(): boolean {
+    return Boolean(this.config.publishableKey)
+  }
+
+  private maybeWarnLegacyApiKey(): void {
+    if (this.usePublishableKey() || this.warnedLegacyApiKey) {
+      return
+    }
+    this.warnedLegacyApiKey = true
+    console.warn(
+      '[Ordify] Using legacy apiKey in browser. For production embeds, use publishableKey from user settings.'
+    )
+  }
+
+  private getAuthHeaders(includeContentType = false): HeadersInit {
+    if (this.usePublishableKey()) {
+      return {
+        ...(includeContentType ? { 'Content-Type': 'application/json' } : {}),
+        'x-ordify-publishable-key': this.config.publishableKey as string,
+        'accept': 'application/json'
+      }
+    }
+
+    this.maybeWarnLegacyApiKey()
+    return {
+      ...(includeContentType ? { 'Content-Type': 'application/json' } : {}),
+      'api-key': this.config.apiKey as string,
+      'accept': 'application/json'
+    }
   }
 
   async sendMessage(content: string, sessionId?: string, context?: string): Promise<ReadableStream<Uint8Array>> {
-    const url = `${this.config.apiBaseUrl}/chat/agents/${this.config.agentId}`
-    
+    const path = this.usePublishableKey()
+      ? `/widget/chat/${this.config.agentId}`
+      : `/chat/agents/${this.config.agentId}`
+    const url = `${this.config.apiBaseUrl}${path}`
+
     const requestBody: ChatRequest = {
       message: content,
       sessionId: sessionId,
@@ -18,11 +59,7 @@ export class OrdifyApiClient {
 
     const response = await fetch(url, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'api-key': this.config.apiKey,
-        'accept': 'application/json'
-      },
+      headers: this.getAuthHeaders(true),
       body: JSON.stringify(requestBody)
     })
 
@@ -39,15 +76,12 @@ export class OrdifyApiClient {
   }
 
   async createSession(): Promise<Session> {
-    const url = `${this.config.apiBaseUrl}/sessions`
-    
+    const path = this.usePublishableKey() ? '/widget/sessions' : '/sessions'
+    const url = `${this.config.apiBaseUrl}${path}`
+
     const response = await fetch(url, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'api-key': this.config.apiKey,
-        'accept': 'application/json'
-      },
+      headers: this.getAuthHeaders(true),
       body: JSON.stringify({
         name: 'Chat Session',
         agentConfig: {
@@ -65,54 +99,15 @@ export class OrdifyApiClient {
     return response.json()
   }
 
-  async getAgents(): Promise<Agent[]> {
-    const url = `${this.config.apiBaseUrl}/chat/agents`
-    
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: {
-        'api-key': this.config.apiKey,
-        'accept': 'application/json'
-      }
-    })
-
-    if (!response.ok) {
-      const error: ApiError = await response.json()
-      throw new Error(`API Error: ${error.detail}`)
-    }
-
-    const data = await response.json()
-    return data.agents || []
-  }
-
-  async getSessions(): Promise<Session[]> {
-    const url = `${this.config.apiBaseUrl}/sessions`
-    
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: {
-        'api-key': this.config.apiKey,
-        'accept': 'application/json'
-      }
-    })
-
-    if (!response.ok) {
-      const error: ApiError = await response.json()
-      throw new Error(`API Error: ${error.detail}`)
-    }
-
-    return response.json()
-  }
-
   async getSessionWithMessages(sessionId: string): Promise<{ session: Session; messages: Message[] }> {
-    const url = `${this.config.apiBaseUrl}/sessions/${sessionId}/with-messages`
-    
+    const path = this.usePublishableKey()
+      ? `/widget/sessions/${sessionId}/with-messages`
+      : `/sessions/${sessionId}/with-messages`
+    const url = `${this.config.apiBaseUrl}${path}`
+
     const response = await fetch(url, {
       method: 'GET',
-      headers: {
-        'api-key': this.config.apiKey,
-        'accept': 'application/json'
-      }
+      headers: this.getAuthHeaders()
     })
 
     if (!response.ok) {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,4 +1,4 @@
-import { ApiError, ChatRequest, Message, OrdifyApiClientConfig, Session, StreamingResponse } from '@/types'
+import { Agent, ApiError, ChatRequest, Message, OrdifyApiClientConfig, Session, StreamingResponse } from '@/types'
 
 export class OrdifyApiClient {
   private config: OrdifyApiClientConfig
@@ -108,6 +108,47 @@ export class OrdifyApiClient {
     const response = await fetch(url, {
       method: 'GET',
       headers: this.getAuthHeaders()
+    })
+
+    if (!response.ok) {
+      const error: ApiError = await response.json()
+      throw new Error(`API Error: ${error.detail}`)
+    }
+
+    return response.json()
+  }
+
+  /** @deprecated Use the Ordify dashboard to list agents. Will be removed in a future major version. */
+  async getAgents(): Promise<Agent[]> {
+    if (!this.config.apiKey) {
+      throw new Error('[Ordify] getAgents() requires apiKey and is not supported with publishableKey.')
+    }
+    const url = `${this.config.apiBaseUrl}/chat/agents`
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { 'api-key': this.config.apiKey, 'accept': 'application/json' }
+    })
+
+    if (!response.ok) {
+      const error: ApiError = await response.json()
+      throw new Error(`API Error: ${error.detail}`)
+    }
+
+    const data = await response.json()
+    return data.agents || []
+  }
+
+  /** @deprecated Use sessionId prop to load sessions. Will be removed in a future major version. */
+  async getSessions(): Promise<Session[]> {
+    if (!this.config.apiKey) {
+      throw new Error('[Ordify] getSessions() requires apiKey and is not supported with publishableKey.')
+    }
+    const url = `${this.config.apiBaseUrl}/sessions`
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { 'api-key': this.config.apiKey, 'accept': 'application/json' }
     })
 
     if (!response.ok) {

--- a/static/wordpress-demo.html
+++ b/static/wordpress-demo.html
@@ -101,8 +101,12 @@
       <input id="agent-id" type="text" placeholder="Enter your Agent ID" />
     </div>
     <div class="field">
-      <label for="api-key">API Key *</label>
-      <input id="api-key" type="password" placeholder="Enter your API Key" />
+      <label for="publishable-key">Publishable Key *</label>
+      <input id="publishable-key" type="password" placeholder="Enter your pk_live_..." />
+    </div>
+    <div class="field">
+      <label for="api-key">API Key (legacy)</label>
+      <input id="api-key" type="password" placeholder="Optional legacy API key" />
     </div>
     <div class="field">
       <label for="api-base-url">API Base URL *</label>
@@ -121,9 +125,10 @@
 
     function getConfig() {
       var agentId = document.getElementById('agent-id').value.trim();
+      var publishableKey = document.getElementById('publishable-key').value.trim();
       var apiKey = document.getElementById('api-key').value.trim();
       var apiBaseUrl = document.getElementById('api-base-url').value.trim() || 'https://r.ordify.ai';
-      return { agentId: agentId, apiKey: apiKey, apiBaseUrl: apiBaseUrl };
+      return { agentId: agentId, publishableKey: publishableKey, apiKey: apiKey, apiBaseUrl: apiBaseUrl };
     }
 
     function loadSaved() {
@@ -132,6 +137,7 @@
         if (saved) {
           var c = JSON.parse(saved);
           document.getElementById('agent-id').value = c.agentId || '';
+          document.getElementById('publishable-key').value = c.publishableKey || '';
           document.getElementById('api-key').value = c.apiKey || '';
           document.getElementById('api-base-url').value = c.apiBaseUrl || 'https://r.ordify.ai';
           return c;
@@ -145,11 +151,12 @@
     }
 
     function mountWidget(config) {
-      if (!config.agentId || !config.apiKey) return;
+      if (!config.agentId || (!config.publishableKey && !config.apiKey)) return;
       var existing = document.getElementById(ROOT_ID);
       if (existing) existing.remove();
       OrdifyChatWidget.mount(null, {
         agentId: config.agentId,
+        publishableKey: config.publishableKey,
         apiKey: config.apiKey,
         apiBaseUrl: config.apiBaseUrl || 'https://r.ordify.ai',
         mode: 'floating',
@@ -161,8 +168,8 @@
 
     function onApply() {
       var config = getConfig();
-      if (!config.agentId || !config.apiKey) {
-        alert('Please enter Agent ID and API Key.');
+      if (!config.agentId || (!config.publishableKey && !config.apiKey)) {
+        alert('Please enter Agent ID and a Publishable Key (or legacy API Key).');
         return;
       }
       saveConfig(config);
@@ -171,7 +178,7 @@
 
     loadSaved();
     var saved = getConfig();
-    if (saved && saved.agentId && saved.apiKey) mountWidget(saved);
+    if (saved && saved.agentId && (saved.publishableKey || saved.apiKey)) mountWidget(saved);
 
     document.getElementById('apply-btn').addEventListener('click', onApply);
   </script>


### PR DESCRIPTION
## Publishable Key Support

### Overview
This PR updates the chat widget to support publishable keys (`pk_live_...`) as the primary authentication method for browser embeds. The widget now sends requests to `/widget/*` endpoints when a publishable key is provided, while maintaining backward compatibility with legacy `apiKey` during the migration period.

### Key Changes

- **API Client Refactor** (`src/utils/api.ts`)
  - Conditional routing: `/widget/*` for publishable key, `/chat/*` for legacy API key
  - Header selection: `x-ordify-publishable-key` vs `api-key`
  - Warning console message when using legacy API key in browser
  - Removed unused endpoints (`getAgents`, `getSessions`) from embed bundle

- **Configuration** (`src/types/index.ts`, `src/hooks/useOrdifyConfig.ts`)
  - Added `publishableKey` as optional prop
  - `apiKey` marked as optional (legacy)
  - Validation: requires either `publishableKey` or `apiKey`
  - Precedence: `publishableKey` wins if both provided

- **Standalone Script** (`src/standalone.tsx`)
  - Added `data-ordify-publishable-key` attribute support
  - Console warning for legacy `data-ordify-api-key` usage
  - Updated error messages to mention publishable key

- **Documentation Updates** (`README.md`, `examples/*`)
  - All examples now use `publishableKey` / `pk_live_...`
  - Added production security warning: "Keep account API keys on servers"
  - Updated attribute tables and quick start guides
  - Legacy `apiKey` now documented as "supported but discouraged"

### Migration Path

| Before | After |
|--------|-------|
| `apiKey="sk_..."` | `publishableKey="pk_live_..."` |
| `data-ordify-api-key` | `data-ordify-publishable-key` |
| `NEXT_PUBLIC_ORDIFY_API_KEY` | `NEXT_PUBLIC_ORDIFY_PUBLISHABLE_KEY` |

**Backward compatibility**: Widgets using `apiKey` continue to work with a console warning. No breaking change until deprecation window closes.

### Testing

- Verified widget works with only `publishableKey` provided
- Confirmed backward compatibility with only `apiKey` (legacy)
- Tested both `data-*` attributes and React props
- Validated API endpoint routing (widget uses `/widget/*`, legacy uses `/chat/*`)
- Checked error messages when no credential provided

### Example Usage

```html
<!-- New recommended approach -->
<script src="https://cdn.ordify.ai/widget/latest/ordify-chat-widget.standalone.js"
  data-ordify-widget
  data-ordify-agent-id="agent-123"
  data-ordify-publishable-key="pk_live_..."></script>
```

```tsx
// React with publishable key
<OrdifyChat
  agentId="agent-123"
  publishableKey="pk_live_..."
  mode="floating"
/>
```

**Closes:** AD-573