### PR TITLE
Feat/ad 591 widget attachment support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.45] - 2026-05-04
+
+### Added
+- **Widget attachments**: Optional `enableAttachments`, `maxAttachmentSizeMB`, `maxAttachments`, and `allowedAttachmentTypes` on `OrdifyConfig`. When enabled with a **publishable key**, users can attach documents and images (paperclip + drag/drop). Files upload to `POST /widget/attachments` and are sent as `attachments` on chat.
+- **`uploadAttachment` on `useOrdifyChat`**: Programmatic upload using the same auth as the widget.
+- **`Message.attachments`**: User bubbles can show attachment chips; history hydration maps server `attachments` when present.
+
+### Notes
+- Embeds using **API key only** cannot use widget upload (picker stays off); use a publishable key for browser uploads.
+- Configure a GCS lifecycle rule on the `widget_attachments/` prefix in your bucket for retention (ops).
+
 ## [1.0.27] - 2024-12-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ Before integrating the chat widget, ensure you have:
 
 - **Node.js**: 18.0.0 or higher
 - **npm**: 9.0.0 or higher  
-- **API Key**: Available in your Ordify dashboard (Account → Settings → API)
+- **Publishable Key (`pk_live_...`)**: Create in Ordify dashboard (Settings → Publishable Keys)
 - **Agent ID**: Found in your agent configuration panel within the Ordify application
 - **React Application**: Compatible with React 18+ and modern build tools
 
 
 > **🚀 Try it live!** Visit [app.ordify.ai/widget-demo](https://app.ordify.ai/widget-demo) to see all chat modes in action.
+
+> **Production Security:** Use `publishableKey`/`data-ordify-publishable-key` with allowed origins. Keep account `apiKey` for server-side use only.
 
 ## ✨ Features
 
@@ -65,7 +67,7 @@ function App() {
   return (
     <OrdifyChat
       agentId="your-agent-id"
-      apiKey="your-api-key"
+      publishableKey="pk_live_..."
       apiBaseUrl="https://r.ordify.ai"
       chatName="AI Assistant"
       buttonText="Chat with us"
@@ -107,7 +109,7 @@ Load the standalone script from a CDN (use a version number to pin; replace `1.0
 <script>
   OrdifyChatWidget.mount(null, {
     agentId: "your-agent-id",
-    apiKey: "your-api-key",
+    publishableKey: "pk_live_...",
     apiBaseUrl: "https://r.ordify.ai",
     mode: "floating",
     position: "bottom-right",
@@ -123,7 +125,7 @@ Load the standalone script from a CDN (use a version number to pin; replace `1.0
 <script>
   OrdifyChatWidget.mount(null, {
     agentId: "your-agent-id",
-    apiKey: "your-api-key",
+    publishableKey: "pk_live_...",
     apiBaseUrl: "https://r.ordify.ai",
     buttonText: "Chat with us"
   });
@@ -142,7 +144,7 @@ Add a single script tag with `data-ordify-widget` and the required/optional data
   src="https://unpkg.com/ordify-chat-widget@1.0.38/dist/ordify-chat-widget.standalone.js"
   data-ordify-widget
   data-ordify-agent-id="your-agent-id"
-  data-ordify-api-key="your-api-key"
+  data-ordify-publishable-key="pk_live_..."
   data-ordify-api-base-url="https://r.ordify.ai"
   data-ordify-button-text="Chat with us"
   data-ordify-chat-name="AI Assistant"
@@ -150,12 +152,13 @@ Add a single script tag with `data-ordify-widget` and the required/optional data
 ></script>
 ```
 
-**Supported data attributes (all optional except agent-id and api-key):**
+**Supported data attributes (all optional except agent-id and one credential):**
 
 | Attribute | Description |
 |-----------|-------------|
 | `data-ordify-agent-id` | **Required.** Your Ordify agent ID. |
-| `data-ordify-api-key` | **Required.** Your API key. |
+| `data-ordify-publishable-key` | Recommended. Your publishable key (`pk_live_...`) for browser embeds. |
+| `data-ordify-api-key` | Legacy/deprecated for browser embeds. Prefer publishable key. |
 | `data-ordify-api-base-url` | API base URL (default: `https://r.ordify.ai`). |
 | `data-ordify-button-text` | Floating button label. |
 | `data-ordify-chat-name` | Chat header title. |
@@ -176,10 +179,10 @@ Add a single script tag with `data-ordify-widget` and the required/optional data
 
 **Where to put your API key and Agent ID**
 
-The widget does **not** use a separate config file. You put the Agent ID and API key in the same place as the script:
+The widget does **not** use a separate config file. You put the Agent ID and credential in the same place as the script:
 
-- **Option 1 (script + mount):** In the inline snippet, replace `"your-agent-id"` and `"your-api-key"` with your real values. That snippet lives wherever you add it (theme header/footer or a plugin’s “custom code” field).
-- **Option 2 (data attributes):** In the script tag, set `data-ordify-agent-id="your-agent-id"` and `data-ordify-api-key="your-api-key"` (and optionally `data-ordify-api-base-url`). Again, that tag is added via theme or plugin.
+- **Option 1 (script + mount):** In the inline snippet, replace `"your-agent-id"` and `"pk_live_..."` with your real values.
+- **Option 2 (data attributes):** In the script tag, set `data-ordify-agent-id="your-agent-id"` and `data-ordify-publishable-key="pk_live_..."` (and optionally `data-ordify-api-base-url`).
 
 So the “config” is the snippet or script tag you paste; the credentials are inside it.
 
@@ -197,7 +200,7 @@ So the “config” is the snippet or script tag you paste; the credentials are 
 ```tsx
 <OrdifyChat
   agentId="your-agent-id"
-  apiKey="your-api-key"
+  publishableKey="pk_live_..."
   mode="floating"
   position="bottom-right"
   buttonText="AI Chat"
@@ -208,7 +211,7 @@ So the “config” is the snippet or script tag you paste; the credentials are 
 ```tsx
 <OrdifyChat
   agentId="your-agent-id"
-  apiKey="your-api-key"
+  publishableKey="pk_live_..."
   mode="embedded"
   height="500px"
   chatName="Support Assistant"
@@ -223,7 +226,8 @@ So the “config” is the snippet or script tag you paste; the credentials are 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `agentId` | string | - | **Required** - Your Ordify agent ID |
-| `apiKey` | string | - | **Required** - Your API key |
+| `publishableKey` | string | - | Recommended for browser embeds (`pk_live_...`) |
+| `apiKey` | string | - | Legacy browser credential (supported for migration) |
 | `apiBaseUrl` | string | - | **Required** - API endpoint URL |
 | `chatName` | string | "Chat Assistant" | Title text in chat header |
 | `buttonText` | string | "AI Chat" | Text on floating button |

--- a/examples/integration/README.md
+++ b/examples/integration/README.md
@@ -21,7 +21,7 @@ This directory contains code snippets showing how to integrate the Ordify Chat W
 
 3. **Replace the configuration** with your actual values:
    - `agentId` - Your Ordify agent ID
-   - `apiKey` - Your API key
+   - `publishableKey` - Your publishable key (`pk_live_...`)
    - `apiBaseUrl` - API endpoint URL (defaults to https://r.ordify.ai)
 
 4. **Customize** the chat appearance and behavior as needed
@@ -42,7 +42,7 @@ For production, use environment variables:
 ```bash
 # .env.local
 NEXT_PUBLIC_ORDIFY_AGENT_ID=your-agent-id
-NEXT_PUBLIC_ORDIFY_API_KEY=your-api-key
+NEXT_PUBLIC_ORDIFY_PUBLISHABLE_KEY=pk_live_...
 NEXT_PUBLIC_ORDIFY_API_URL=https://r.ordify.ai
 ```
 

--- a/examples/integration/landing-page.tsx
+++ b/examples/integration/landing-page.tsx
@@ -26,7 +26,7 @@ export default function HomePage() {
       {/* Add floating chat widget */}
       <OrdifyChat
         agentId="your-agent-id"
-        apiKey="your-api-key"
+        publishableKey="pk_live_..."
         apiBaseUrl="https://r.ordify.ai"
         mode="floating"
         position="bottom-right"

--- a/examples/integration/nextjs-app-router.tsx
+++ b/examples/integration/nextjs-app-router.tsx
@@ -10,7 +10,7 @@ export default function ChatPage() {
       <h1 className="text-2xl font-bold mb-4">Chat with AI</h1>
       <OrdifyChat 
         agentId={process.env.NEXT_PUBLIC_ORDIFY_AGENT_ID!}
-        apiKey={process.env.NEXT_PUBLIC_ORDIFY_API_KEY!}
+        publishableKey={process.env.NEXT_PUBLIC_ORDIFY_PUBLISHABLE_KEY!}
         apiBaseUrl="https://r.ordify.ai"
         mode="embedded"
         height="500px"

--- a/examples/integration/nextjs-pages-router.tsx
+++ b/examples/integration/nextjs-pages-router.tsx
@@ -8,7 +8,7 @@ export default function ChatPage() {
       <h1 className="text-2xl font-bold mb-4">Chat with AI</h1>
       <OrdifyChat 
         agentId={process.env.NEXT_PUBLIC_ORDIFY_AGENT_ID!}
-        apiKey={process.env.NEXT_PUBLIC_ORDIFY_API_KEY!}
+        publishableKey={process.env.NEXT_PUBLIC_ORDIFY_PUBLISHABLE_KEY!}
         apiBaseUrl="https://r.ordify.ai"
         mode="embedded"
         height="500px"

--- a/examples/integration/react-component.tsx
+++ b/examples/integration/react-component.tsx
@@ -6,7 +6,7 @@ export function ChatWidget() {
   return (
     <OrdifyChat
       agentId="your-agent-id"
-      apiKey="your-api-key"
+      publishableKey="pk_live_..."
       apiBaseUrl="https://api.ordify.ai"
       mode="floating"
       position="bottom-right"

--- a/examples/integration/support-page.tsx
+++ b/examples/integration/support-page.tsx
@@ -34,7 +34,7 @@ export default function SupportPage() {
             
             <OrdifyChat
               agentId="your-agent-id"
-              apiKey="your-api-key"
+              publishableKey="pk_live_..."
               apiBaseUrl="https://r.ordify.ai"
               mode="embedded"
               height="400px"

--- a/src/components/AttachmentChips.tsx
+++ b/src/components/AttachmentChips.tsx
@@ -1,0 +1,97 @@
+import { AttachmentItem } from '@/types'
+import { FileText, Image as ImageIcon, X } from 'lucide-react'
+import styled from 'styled-components'
+
+const Row = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 6px;
+`
+
+const Chip = styled.div<{ $isImage?: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 220px;
+  padding: 4px 8px;
+  border-radius: 8px;
+  font-size: 12px;
+  background: ${(p) => (p.$isImage ? 'rgba(59, 130, 246, 0.12)' : 'rgba(107, 114, 128, 0.12)')};
+  color: #374151;
+  border: 1px solid #e5e7eb;
+
+  [data-theme='dark'] & {
+    color: #e5e7eb;
+    border-color: #4b5563;
+    background: ${(p) => (p.$isImage ? 'rgba(59, 130, 246, 0.2)' : 'rgba(107, 114, 128, 0.25)')};
+  }
+`
+
+const Thumb = styled.img`
+  width: 28px;
+  height: 28px;
+  object-fit: cover;
+  border-radius: 4px;
+`
+
+const Name = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+`
+
+const RemoveBtn = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #6b7280;
+  border-radius: 4px;
+
+  &:hover {
+    color: #ef4444;
+    background: rgba(239, 68, 68, 0.1);
+  }
+`
+
+interface AttachmentChipsProps {
+  attachments: AttachmentItem[]
+  onRemove?: (id: string) => void
+  readOnly?: boolean
+}
+
+export function AttachmentChips({ attachments, onRemove, readOnly }: AttachmentChipsProps) {
+  if (!attachments.length) return null
+
+  return (
+    <Row>
+      {attachments.map((a) => {
+        const isImage = a.type === 'image'
+        const showThumb = isImage && (a.preview || a.url)
+        return (
+          <Chip key={a.id} $isImage={isImage} title={a.name}>
+            {showThumb ? (
+              <Thumb src={a.preview || a.url} alt="" loading="lazy" decoding="async" />
+            ) : isImage ? (
+              <ImageIcon size={16} aria-hidden />
+            ) : (
+              <FileText size={16} aria-hidden />
+            )}
+            <Name>{a.name}</Name>
+            {!readOnly && onRemove && (
+              <RemoveBtn type="button" onClick={() => onRemove(a.id)} aria-label={`Remove ${a.name}`}>
+                <X size={14} />
+              </RemoveBtn>
+            )}
+          </Chip>
+        )
+      })}
+    </Row>
+  )
+}

--- a/src/components/AttachmentPicker.tsx
+++ b/src/components/AttachmentPicker.tsx
@@ -1,0 +1,138 @@
+import { AttachmentItem } from '@/types'
+import {
+  DEFAULT_WIDGET_ALLOWED_MIMES,
+  validateWidgetAttachmentFile
+} from '@/utils/attachments'
+import { Paperclip } from 'lucide-react'
+import React from 'react'
+import styled from 'styled-components'
+
+const IconButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  min-width: 36px;
+  min-height: 36px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  background: #f9fafb;
+  color: #374151;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s ease, border-color 0.15s ease;
+
+  &:hover:not(:disabled) {
+    background: #f3f4f6;
+    border-color: #9ca3af;
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  [data-theme='dark'] & {
+    background: #374151;
+    border-color: #4b5563;
+    color: #e5e7eb;
+  }
+`
+
+interface AttachmentPickerProps {
+  disabled?: boolean
+  maxFileBytes: number
+  maxFiles: number
+  allowedMime?: readonly string[]
+  currentCount: number
+  uploadAttachment: (file: File) => Promise<AttachmentItem>
+  onUploaded: (item: AttachmentItem) => void
+  onError?: (message: string) => void
+}
+
+export function AttachmentPicker({
+  disabled,
+  maxFileBytes,
+  maxFiles,
+  allowedMime = DEFAULT_WIDGET_ALLOWED_MIMES,
+  currentCount,
+  uploadAttachment,
+  onUploaded,
+  onError
+}: AttachmentPickerProps) {
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const [busy, setBusy] = React.useState(false)
+
+  const accept = React.useMemo(
+    () =>
+      [
+        '.pdf,.docx,.xlsx,.xls,.csv,.txt,.md,.json',
+        'image/png,image/jpeg,image/webp,image/gif'
+      ].join(','),
+    []
+  )
+
+  const processFiles = React.useCallback(
+    async (files: FileList | File[]) => {
+      const list = Array.from(files)
+      if (!list.length) return
+
+      let added = 0
+      for (const file of list) {
+        if (currentCount + added >= maxFiles) {
+          onError?.(`You can attach at most ${maxFiles} files per message.`)
+          break
+        }
+        const err = validateWidgetAttachmentFile(file, maxFileBytes, allowedMime)
+        if (err) {
+          onError?.(`${file.name}: ${err}`)
+          continue
+        }
+        try {
+          setBusy(true)
+          const item = await uploadAttachment(file)
+          onUploaded(item)
+          added += 1
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : 'Upload failed'
+          onError?.(msg)
+        } finally {
+          setBusy(false)
+        }
+      }
+    },
+    [allowedMime, currentCount, maxFileBytes, maxFiles, onError, onUploaded, uploadAttachment]
+  )
+
+  const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files
+    if (f?.length) void processFiles(f)
+    e.target.value = ''
+  }
+
+  const atLimit = currentCount >= maxFiles
+  const isDisabled = Boolean(disabled || busy || atLimit)
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        multiple
+        accept={accept}
+        style={{ display: 'none' }}
+        onChange={onInputChange}
+      />
+      <IconButton
+        type="button"
+        disabled={isDisabled}
+        aria-label="Attach file"
+        title="Attach file"
+        onClick={() => inputRef.current?.click()}
+      >
+        <Paperclip size={18} />
+      </IconButton>
+    </>
+  )
+}

--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -7,6 +7,9 @@ interface ConversationProps {
   className?: string
   children: React.ReactNode
   style?: React.CSSProperties
+  onDragOver?: React.DragEventHandler<HTMLDivElement>
+  onDragLeave?: React.DragEventHandler<HTMLDivElement>
+  onDrop?: React.DragEventHandler<HTMLDivElement>
 }
 
 interface ConversationContentProps {
@@ -71,7 +74,14 @@ const ScrollButton = styled.button`
   }
 `
 
-export function Conversation({ className, children, style }: ConversationProps) {
+export function Conversation({
+  className,
+  children,
+  style,
+  onDragOver,
+  onDragLeave,
+  onDrop
+}: ConversationProps) {
   return (
     <StyledStickToBottom
       className={className}
@@ -79,6 +89,9 @@ export function Conversation({ className, children, style }: ConversationProps) 
       initial="smooth"
       resize="smooth"
       role="log"
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
     >
       {children}
     </StyledStickToBottom>

--- a/src/components/EmbeddedChat.tsx
+++ b/src/components/EmbeddedChat.tsx
@@ -1,7 +1,11 @@
+import { AttachmentChips } from '@/components/AttachmentChips'
+import { AttachmentPicker } from '@/components/AttachmentPicker'
 import { MarkdownRenderer } from '@/components/MarkdownRenderer'
 import { ProfessionalInput } from '@/components/ProfessionalInput'
 import { WelcomeScreen } from '@/components/WelcomeScreen'
+import { useWidgetAttachmentStaging } from '@/hooks/useWidgetAttachmentStaging'
 import { OrdifyConfig, UseOrdifyChatReturn } from '@/types'
+import { filesFromDataTransfer } from '@/utils/attachments'
 import { SendIcon } from './SendIcon'
 import React from 'react'
 import { Conversation, ConversationContent } from './Conversation'
@@ -21,10 +25,24 @@ interface EmbeddedChatProps {
 }
 
 export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
-  const { messages, sendMessage, isLoading, error, hasSessionStarted } = chat
+  const { messages, sendMessage, uploadAttachment, isLoading, error, hasSessionStarted } = chat
   const [inputValue, setInputValue] = React.useState('')
   const [isDarkMode, setIsDarkMode] = React.useState(false)
   const inputRef = React.useRef<HTMLTextAreaElement>(null)
+
+  const {
+    enabled: attachmentsEnabled,
+    staged: stagedAttachments,
+    attachmentError,
+    setAttachmentError,
+    addFiles,
+    appendStaged,
+    removeStaged,
+    clearStaged,
+    maxFiles,
+    maxBytes,
+    allowed
+  } = useWidgetAttachmentStaging(config, uploadAttachment)
 
   const getThemeValue = () => {
     if (config.theme === 'dark') return 'dark'
@@ -49,10 +67,12 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
   }, [config.theme])
 
   const handleSendMessage = async () => {
-    if (!inputValue.trim() || isLoading) return
+    const trimmed = inputValue.trim()
+    if ((!trimmed && stagedAttachments.length === 0) || isLoading) return
 
-    await sendMessage(inputValue.trim())
+    await sendMessage(trimmed, undefined, stagedAttachments.length ? stagedAttachments : undefined)
     setInputValue('')
+    clearStaged()
 
     // Auto-focus input after sending
     setTimeout(() => {
@@ -85,6 +105,19 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
     }
   }, [config.height])
 
+  const onDragOver = (e: React.DragEvent) => {
+    if (!attachmentsEnabled) return
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'copy'
+  }
+
+  const onDrop = async (e: React.DragEvent) => {
+    if (!attachmentsEnabled) return
+    e.preventDefault()
+    const files = await filesFromDataTransfer(e.dataTransfer)
+    if (files.length) await addFiles(files)
+  }
+
   return (
     <ChatWidget
       data-theme={getThemeValue()}
@@ -102,7 +135,7 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
         />
       ) : (
         <>
-          <Conversation style={{ flex: 1 }}>
+          <Conversation style={{ flex: 1 }} onDragOver={onDragOver} onDrop={onDrop}>
             <ConversationContent>
               {messages.map(message => (
                 <div
@@ -126,7 +159,12 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
                     {message.role === 'assistant' ? (
                       <MarkdownRenderer content={message.content} />
                     ) : (
-                      message.content
+                      <>
+                        {message.attachments && message.attachments.length > 0 && (
+                          <AttachmentChips attachments={message.attachments} readOnly />
+                        )}
+                        {message.content ? message.content : null}
+                      </>
                     )}
                   </ChatMessage>
                 </div>
@@ -160,21 +198,45 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
           </Conversation>
 
           {/* Chat input */}
-          <ChatInput>
-            <ProfessionalInput
-              ref={inputRef}
-              value={inputValue}
-              onChange={setInputValue}
-              onKeyDown={handleKeyPress}
-              placeholder={config.placeholder}
-              disabled={isLoading}
-            />
-            <SendButton
-              onClick={handleSendMessage}
-              disabled={isLoading || !inputValue.trim()}
-            >
-              <SendIcon size={16} />
-            </SendButton>
+          <ChatInput style={{ flexDirection: 'column', alignItems: 'stretch', gap: 0 }}>
+            {(attachmentError || (attachmentsEnabled && stagedAttachments.length > 0)) && (
+              <div style={{ paddingBottom: 8 }}>
+                {attachmentError && (
+                  <div style={{ fontSize: 12, color: '#dc2626', marginBottom: 4 }}>{attachmentError}</div>
+                )}
+                {attachmentsEnabled && stagedAttachments.length > 0 && (
+                  <AttachmentChips attachments={stagedAttachments} onRemove={removeStaged} />
+                )}
+              </div>
+            )}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%' }}>
+              {attachmentsEnabled && (
+                <AttachmentPicker
+                  disabled={isLoading}
+                  maxFileBytes={maxBytes}
+                  maxFiles={maxFiles}
+                  allowedMime={allowed}
+                  currentCount={stagedAttachments.length}
+                  uploadAttachment={uploadAttachment}
+                  onUploaded={appendStaged}
+                  onError={setAttachmentError}
+                />
+              )}
+              <ProfessionalInput
+                ref={inputRef}
+                value={inputValue}
+                onChange={setInputValue}
+                onKeyDown={handleKeyPress}
+                placeholder={config.placeholder}
+                disabled={isLoading}
+              />
+              <SendButton
+                onClick={handleSendMessage}
+                disabled={isLoading || (!inputValue.trim() && stagedAttachments.length === 0)}
+              >
+                <SendIcon size={16} />
+              </SendButton>
+            </div>
           </ChatInput>
         </>
       )}

--- a/src/components/FloatingChat.tsx
+++ b/src/components/FloatingChat.tsx
@@ -1,8 +1,12 @@
+import { AttachmentChips } from '@/components/AttachmentChips'
+import { AttachmentPicker } from '@/components/AttachmentPicker'
 import { Conversation, ConversationContent } from '@/components/Conversation'
 import { MarkdownRenderer } from '@/components/MarkdownRenderer'
 import { ProfessionalInput } from '@/components/ProfessionalInput'
 import { WelcomeScreen } from '@/components/WelcomeScreen'
+import { useWidgetAttachmentStaging } from '@/hooks/useWidgetAttachmentStaging'
 import { OrdifyConfig, UseOrdifyChatReturn } from '@/types'
+import { filesFromDataTransfer } from '@/utils/attachments'
 import { MessageSquareIcon } from './Icons'
 import { SendIcon } from './SendIcon'
 import React from 'react'
@@ -25,11 +29,25 @@ interface FloatingChatProps {
 }
 
 export function FloatingChat({ config, chat }: FloatingChatProps) {
-  const { messages, sendMessage, isLoading, error, isOpen, setIsOpen, hasSessionStarted } = chat
+  const { messages, sendMessage, uploadAttachment, isLoading, error, isOpen, setIsOpen, hasSessionStarted } = chat
   const [inputValue, setInputValue] = React.useState('')
   const [chatHeight, setChatHeight] = React.useState<number | string>(config.height || 600)
   const [isDarkMode, setIsDarkMode] = React.useState(false)
   const inputRef = React.useRef<HTMLTextAreaElement>(null)
+
+  const {
+    enabled: attachmentsEnabled,
+    staged: stagedAttachments,
+    attachmentError,
+    setAttachmentError,
+    addFiles,
+    appendStaged,
+    removeStaged,
+    clearStaged,
+    maxFiles,
+    maxBytes,
+    allowed
+  } = useWidgetAttachmentStaging(config, uploadAttachment)
 
   const getThemeValue = () => {
     if (config.theme === 'dark') return 'dark'
@@ -54,10 +72,12 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
   }, [config.theme])
 
   const handleSendMessage = async () => {
-    if (!inputValue.trim() || isLoading) return
+    const trimmed = inputValue.trim()
+    if ((!trimmed && stagedAttachments.length === 0) || isLoading) return
 
-    await sendMessage(inputValue.trim())
+    await sendMessage(trimmed, undefined, stagedAttachments.length ? stagedAttachments : undefined)
     setInputValue('')
+    clearStaged()
 
     // Auto-focus input after sending
     setTimeout(() => {
@@ -72,6 +92,18 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
     }
   }
 
+  const onDragOver = (e: React.DragEvent) => {
+    if (!attachmentsEnabled) return
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'copy'
+  }
+
+  const onDrop = async (e: React.DragEvent) => {
+    if (!attachmentsEnabled) return
+    e.preventDefault()
+    const files = await filesFromDataTransfer(e.dataTransfer)
+    if (files.length) await addFiles(files)
+  }
 
   if (!isOpen) {
     return (
@@ -150,7 +182,7 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
         />
       ) : (
         <>
-          <Conversation>
+          <Conversation onDragOver={onDragOver} onDrop={onDrop}>
             <ConversationContent>
               {messages.map(message => (
                 <div
@@ -174,7 +206,12 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
                     {message.role === 'assistant' ? (
                       <MarkdownRenderer content={message.content} />
                     ) : (
-                      message.content
+                      <>
+                        {message.attachments && message.attachments.length > 0 && (
+                          <AttachmentChips attachments={message.attachments} readOnly />
+                        )}
+                        {message.content ? message.content : null}
+                      </>
                     )}
                   </ChatMessage>
                 </div>
@@ -208,21 +245,45 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
           </Conversation>
 
           {/* Chat input - Full width */}
-          <ChatInput>
-            <ProfessionalInput
-              ref={inputRef}
-              value={inputValue}
-              onChange={setInputValue}
-              onKeyDown={handleKeyPress}
-              placeholder={config.placeholder}
-              disabled={isLoading}
-            />
-            <SendButton
-              onClick={handleSendMessage}
-              disabled={isLoading || !inputValue.trim()}
-            >
-              <SendIcon size={16} />
-            </SendButton>
+          <ChatInput style={{ flexDirection: 'column', alignItems: 'stretch', gap: 0 }}>
+            {(attachmentError || (attachmentsEnabled && stagedAttachments.length > 0)) && (
+              <div style={{ paddingBottom: 8 }}>
+                {attachmentError && (
+                  <div style={{ fontSize: 12, color: '#dc2626', marginBottom: 4 }}>{attachmentError}</div>
+                )}
+                {attachmentsEnabled && stagedAttachments.length > 0 && (
+                  <AttachmentChips attachments={stagedAttachments} onRemove={removeStaged} />
+                )}
+              </div>
+            )}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%' }}>
+              {attachmentsEnabled && (
+                <AttachmentPicker
+                  disabled={isLoading}
+                  maxFileBytes={maxBytes}
+                  maxFiles={maxFiles}
+                  allowedMime={allowed}
+                  currentCount={stagedAttachments.length}
+                  uploadAttachment={uploadAttachment}
+                  onUploaded={appendStaged}
+                  onError={setAttachmentError}
+                />
+              )}
+              <ProfessionalInput
+                ref={inputRef}
+                value={inputValue}
+                onChange={setInputValue}
+                onKeyDown={handleKeyPress}
+                placeholder={config.placeholder}
+                disabled={isLoading}
+              />
+              <SendButton
+                onClick={handleSendMessage}
+                disabled={isLoading || (!inputValue.trim() && stagedAttachments.length === 0)}
+              >
+                <SendIcon size={16} />
+              </SendButton>
+            </div>
           </ChatInput>
         </>
       )}

--- a/src/components/InlineChat.tsx
+++ b/src/components/InlineChat.tsx
@@ -1,7 +1,11 @@
+import { AttachmentChips } from '@/components/AttachmentChips'
+import { AttachmentPicker } from '@/components/AttachmentPicker'
 import { MarkdownRenderer } from '@/components/MarkdownRenderer'
 import { ProfessionalInput } from '@/components/ProfessionalInput'
 import { WelcomeScreen } from '@/components/WelcomeScreen'
+import { useWidgetAttachmentStaging } from '@/hooks/useWidgetAttachmentStaging'
 import { OrdifyConfig, UseOrdifyChatReturn } from '@/types'
+import { filesFromDataTransfer } from '@/utils/attachments'
 import { SendIcon } from './SendIcon'
 import React from 'react'
 import { Conversation, ConversationContent } from './Conversation'
@@ -21,15 +25,31 @@ interface InlineChatProps {
 }
 
 export function InlineChat({ config, chat }: InlineChatProps) {
-  const { messages, sendMessage, isLoading, error, hasSessionStarted } = chat
+  const { messages, sendMessage, uploadAttachment, isLoading, error, hasSessionStarted } = chat
   const [inputValue, setInputValue] = React.useState('')
   const inputRef = React.useRef<HTMLTextAreaElement>(null)
 
-  const handleSendMessage = async () => {
-    if (!inputValue.trim() || isLoading) return
+  const {
+    enabled: attachmentsEnabled,
+    staged: stagedAttachments,
+    attachmentError,
+    setAttachmentError,
+    addFiles,
+    appendStaged,
+    removeStaged,
+    clearStaged,
+    maxFiles,
+    maxBytes,
+    allowed
+  } = useWidgetAttachmentStaging(config, uploadAttachment)
 
-    await sendMessage(inputValue.trim())
+  const handleSendMessage = async () => {
+    const trimmed = inputValue.trim()
+    if ((!trimmed && stagedAttachments.length === 0) || isLoading) return
+
+    await sendMessage(trimmed, undefined, stagedAttachments.length ? stagedAttachments : undefined)
     setInputValue('')
+    clearStaged()
 
     // Auto-focus input after sending
     setTimeout(() => {
@@ -42,6 +62,19 @@ export function InlineChat({ config, chat }: InlineChatProps) {
       e.preventDefault()
       handleSendMessage()
     }
+  }
+
+  const onDragOver = (e: React.DragEvent) => {
+    if (!attachmentsEnabled) return
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'copy'
+  }
+
+  const onDrop = async (e: React.DragEvent) => {
+    if (!attachmentsEnabled) return
+    e.preventDefault()
+    const files = await filesFromDataTransfer(e.dataTransfer)
+    if (files.length) await addFiles(files)
   }
 
   return (
@@ -67,7 +100,7 @@ export function InlineChat({ config, chat }: InlineChatProps) {
         />
       ) : (
         <>
-          <Conversation style={{ flex: 1 }}>
+          <Conversation style={{ flex: 1 }} onDragOver={onDragOver} onDrop={onDrop}>
             <ConversationContent>
               {messages.map(message => (
                 <div
@@ -91,7 +124,12 @@ export function InlineChat({ config, chat }: InlineChatProps) {
                     {message.role === 'assistant' ? (
                       <MarkdownRenderer content={message.content} />
                     ) : (
-                      message.content
+                      <>
+                        {message.attachments && message.attachments.length > 0 && (
+                          <AttachmentChips attachments={message.attachments} readOnly />
+                        )}
+                        {message.content ? message.content : null}
+                      </>
                     )}
                   </ChatMessage>
                 </div>
@@ -125,21 +163,45 @@ export function InlineChat({ config, chat }: InlineChatProps) {
           </Conversation>
 
           {/* Chat input */}
-          <ChatInput>
-            <ProfessionalInput
-              ref={inputRef}
-              value={inputValue}
-              onChange={setInputValue}
-              onKeyDown={handleKeyPress}
-              placeholder={config.placeholder}
-              disabled={isLoading}
-            />
-            <SendButton
-              onClick={handleSendMessage}
-              disabled={isLoading || !inputValue.trim()}
-            >
-              <SendIcon size={16} />
-            </SendButton>
+          <ChatInput style={{ flexDirection: 'column', alignItems: 'stretch', gap: 0 }}>
+            {(attachmentError || (attachmentsEnabled && stagedAttachments.length > 0)) && (
+              <div style={{ paddingBottom: 8 }}>
+                {attachmentError && (
+                  <div style={{ fontSize: 12, color: '#dc2626', marginBottom: 4 }}>{attachmentError}</div>
+                )}
+                {attachmentsEnabled && stagedAttachments.length > 0 && (
+                  <AttachmentChips attachments={stagedAttachments} onRemove={removeStaged} />
+                )}
+              </div>
+            )}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%' }}>
+              {attachmentsEnabled && (
+                <AttachmentPicker
+                  disabled={isLoading}
+                  maxFileBytes={maxBytes}
+                  maxFiles={maxFiles}
+                  allowedMime={allowed}
+                  currentCount={stagedAttachments.length}
+                  uploadAttachment={uploadAttachment}
+                  onUploaded={appendStaged}
+                  onError={setAttachmentError}
+                />
+              )}
+              <ProfessionalInput
+                ref={inputRef}
+                value={inputValue}
+                onChange={setInputValue}
+                onKeyDown={handleKeyPress}
+                placeholder={config.placeholder}
+                disabled={isLoading}
+              />
+              <SendButton
+                onClick={handleSendMessage}
+                disabled={isLoading || (!inputValue.trim() && stagedAttachments.length === 0)}
+              >
+                <SendIcon size={16} />
+              </SendButton>
+            </div>
           </ChatInput>
         </>
       )}

--- a/src/demo.tsx
+++ b/src/demo.tsx
@@ -19,6 +19,10 @@ function DemoApp() {
   const [welcomeImage, setWelcomeImage] = useState("")
   const [theme, setTheme] = useState<'light' | 'dark' | 'auto'>('auto')
   const [position, setPosition] = useState<'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'>('bottom-right')
+  const [enableAttachments, setEnableAttachments] = useState(true)
+  const [maxAttachmentSizeMB, setMaxAttachmentSizeMB] = useState(10)
+  const [maxAttachments, setMaxAttachments] = useState(3)
+  const [allowedAttachmentTypesRaw, setAllowedAttachmentTypesRaw] = useState('')
   const [floatingSessionId, setFloatingSessionId] = useState<string | null>(null)
   const [embeddedSessionId, setEmbeddedSessionId] = useState<string | null>(null)
 
@@ -40,6 +44,20 @@ function DemoApp() {
         setWelcomeImage(config.welcomeImage || "")
         setTheme(config.theme || 'auto')
         setPosition(config.position || 'bottom-right')
+        setEnableAttachments(config.enableAttachments !== false)
+        setMaxAttachmentSizeMB(
+          typeof config.maxAttachmentSizeMB === 'number' && config.maxAttachmentSizeMB > 0
+            ? config.maxAttachmentSizeMB
+            : 10
+        )
+        setMaxAttachments(
+          typeof config.maxAttachments === 'number' && config.maxAttachments > 0
+            ? config.maxAttachments
+            : 3
+        )
+        setAllowedAttachmentTypesRaw(
+          typeof config.allowedAttachmentTypesRaw === 'string' ? config.allowedAttachmentTypesRaw : ''
+        )
       } catch (e) {
         console.error('Failed to load saved configuration:', e)
       }
@@ -71,10 +89,14 @@ function DemoApp() {
       welcomeMessage,
       welcomeImage,
       theme,
-      position
+      position,
+      enableAttachments,
+      maxAttachmentSizeMB,
+      maxAttachments,
+      allowedAttachmentTypesRaw
     }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(config))
-  }, [agentId, publishableKey, apiKey, apiBaseUrl, chatName, buttonText, primaryColor, agentImage, quickQuestions, welcomeMessage, welcomeImage, theme, position])
+  }, [agentId, publishableKey, apiKey, apiBaseUrl, chatName, buttonText, primaryColor, agentImage, quickQuestions, welcomeMessage, welcomeImage, theme, position, enableAttachments, maxAttachmentSizeMB, maxAttachments, allowedAttachmentTypesRaw])
 
   // State for dynamic testing
   const [initialMessage, setInitialMessage] = useState("Hi")
@@ -156,10 +178,27 @@ function DemoApp() {
     setWidgetsMounted(true)
   }
 
+  const allowedAttachmentTypesParsed = allowedAttachmentTypesRaw
+    .split(/[\n,]+/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+
+  const attachmentProps = {
+    enableAttachments,
+    maxAttachmentSizeMB,
+    maxAttachments,
+    ...(allowedAttachmentTypesParsed.length > 0
+      ? { allowedAttachmentTypes: allowedAttachmentTypesParsed }
+      : {}),
+  }
+
   return (
     <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
       <h1>Ordify Chat Widget Test</h1>
-      <p>Testing the initialContext feature, button configurability, and auto-scroll</p>
+      <p>
+        Testing the initialContext feature, button configurability, auto-scroll, and optional file
+        attachments (publishable key + backend <code>/widget/attachments</code>).
+      </p>
 
       {/* Configuration Section */}
       <div style={{
@@ -410,6 +449,107 @@ function DemoApp() {
             </div>
           </div>
 
+          <div
+            style={{
+              borderTop: '1px solid #e8e8e8',
+              marginTop: '18px',
+              paddingTop: '18px',
+            }}
+          >
+            <h4 style={{ margin: '0 0 8px 0' }}>Attachments</h4>
+            <p style={{ fontSize: '13px', color: '#666', margin: '0 0 14px 0' }}>
+              Uploads use <strong>POST /widget/attachments</strong> with your publishable key. Without a key, the
+              paperclip stays disabled even if this is checked.
+            </p>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+                gap: '15px',
+                alignItems: 'start',
+              }}
+            >
+              <label
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '10px',
+                  cursor: 'pointer',
+                  fontWeight: 'bold',
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={enableAttachments}
+                  onChange={(e) => setEnableAttachments(e.target.checked)}
+                />
+                Enable attachments
+              </label>
+              <div>
+                <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>
+                  Max file size (MB)
+                </label>
+                <input
+                  type="number"
+                  min={1}
+                  max={100}
+                  value={maxAttachmentSizeMB}
+                  onChange={(e) => setMaxAttachmentSizeMB(Math.max(1, Number(e.target.value) || 1))}
+                  style={{
+                    width: '100%',
+                    maxWidth: '140px',
+                    padding: '8px',
+                    border: '1px solid #ccc',
+                    borderRadius: '4px',
+                  }}
+                />
+              </div>
+              <div>
+                <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>
+                  Max files per message
+                </label>
+                <input
+                  type="number"
+                  min={1}
+                  max={20}
+                  value={maxAttachments}
+                  onChange={(e) => setMaxAttachments(Math.min(20, Math.max(1, Number(e.target.value) || 1)))}
+                  style={{
+                    width: '100%',
+                    maxWidth: '140px',
+                    padding: '8px',
+                    border: '1px solid #ccc',
+                    borderRadius: '4px',
+                  }}
+                />
+              </div>
+              <div style={{ gridColumn: '1 / -1' }}>
+                <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>
+                  Allowed MIME types (optional, one per line or comma-separated)
+                </label>
+                <textarea
+                  value={allowedAttachmentTypesRaw}
+                  onChange={(e) => setAllowedAttachmentTypesRaw(e.target.value)}
+                  style={{
+                    width: '100%',
+                    maxWidth: '560px',
+                    padding: '8px',
+                    border: '1px solid #ccc',
+                    borderRadius: '4px',
+                    minHeight: '72px',
+                    resize: 'vertical',
+                    fontFamily: 'monospace',
+                    fontSize: '12px',
+                  }}
+                  placeholder={'application/pdf\nimage/png,image/jpeg'}
+                />
+                <p style={{ fontSize: '12px', color: '#666', marginTop: '6px', marginBottom: 0 }}>
+                  Leave empty to rely on the widget defaults and server-side checks.
+                </p>
+              </div>
+            </div>
+          </div>
+
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))', gap: '15px' }}>
             <div>
               <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>
@@ -580,7 +720,13 @@ function DemoApp() {
           Context: "{initialContext}"<br /><br />
           <strong>Active Settings:</strong><br />
           Message: "{activeMessage}"<br />
-          Context: "{activeContext}"
+          Context: "{activeContext}"<br /><br />
+          <strong>Attachment settings (saved with Configuration):</strong><br />
+          Enabled: {enableAttachments ? 'yes' : 'no'} · Max size: {maxAttachmentSizeMB} MB · Max files:{' '}
+          {maxAttachments}
+          <br />
+          Allowed MIME:{' '}
+          {allowedAttachmentTypesParsed.length > 0 ? allowedAttachmentTypesParsed.join(', ') : '(defaults)'}
         </div>
       </div>
 
@@ -673,6 +819,7 @@ function DemoApp() {
             onError={(error) => {
               console.error('❌ Floating chat error:', error)
             }}
+            {...attachmentProps}
           />
 
           <div style={{ marginTop: '40px', marginBottom: '20px' }}>
@@ -836,6 +983,7 @@ function DemoApp() {
                 onError={(error) => {
                   console.error('❌ Embedded chat error:', error)
                 }}
+                {...attachmentProps}
               />
             </div>
           </div>

--- a/src/demo.tsx
+++ b/src/demo.tsx
@@ -7,6 +7,7 @@ const SESSION_STORAGE_KEY = 'ordify-demo-sessions'
 
 function DemoApp() {
   const [agentId, setAgentId] = useState("")
+  const [publishableKey, setPublishableKey] = useState("")
   const [apiKey, setApiKey] = useState("")
   const [apiBaseUrl, setApiBaseUrl] = useState("http://localhost:5001")
   const [chatName, setChatName] = useState("Chat Assistant")
@@ -27,6 +28,7 @@ function DemoApp() {
       try {
         const config = JSON.parse(saved)
         setAgentId(config.agentId || "")
+        setPublishableKey(config.publishableKey || "")
         setApiKey(config.apiKey || "")
         setApiBaseUrl(config.apiBaseUrl || "http://localhost:5001")
         setChatName(config.chatName || "Chat Assistant")
@@ -58,6 +60,7 @@ function DemoApp() {
   useEffect(() => {
     const config = {
       agentId,
+      publishableKey,
       apiKey,
       apiBaseUrl,
       chatName,
@@ -71,7 +74,7 @@ function DemoApp() {
       position
     }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(config))
-  }, [agentId, apiKey, apiBaseUrl, chatName, buttonText, primaryColor, agentImage, quickQuestions, welcomeMessage, welcomeImage, theme, position])
+  }, [agentId, publishableKey, apiKey, apiBaseUrl, chatName, buttonText, primaryColor, agentImage, quickQuestions, welcomeMessage, welcomeImage, theme, position])
 
   // State for dynamic testing
   const [initialMessage, setInitialMessage] = useState("Hi")
@@ -192,7 +195,25 @@ function DemoApp() {
 
           <div>
             <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>
-              API Key *
+              Publishable Key (recommended)
+            </label>
+            <input
+              type="password"
+              value={publishableKey}
+              onChange={(e) => setPublishableKey(e.target.value)}
+              style={{
+                width: '100%',
+                padding: '8px',
+                border: '1px solid #ccc',
+                borderRadius: '4px'
+              }}
+              placeholder="Enter your pk_live_..."
+            />
+          </div>
+
+          <div>
+            <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>
+              API Key (legacy)
             </label>
             <input
               type="password"
@@ -625,6 +646,7 @@ function DemoApp() {
           <OrdifyChat
             key={`floating-${testKey}`}
             agentId={agentId}
+            publishableKey={publishableKey}
             apiKey={apiKey}
             apiBaseUrl={apiBaseUrl}
             mode="floating"
@@ -788,6 +810,7 @@ function DemoApp() {
               <OrdifyChat
                 key={`embedded-${testKey}`}
                 agentId={agentId}
+                publishableKey={publishableKey}
                 apiKey={apiKey}
                 apiBaseUrl={apiBaseUrl}
                 mode="embedded"

--- a/src/hooks/useOrdifyChat.ts
+++ b/src/hooks/useOrdifyChat.ts
@@ -22,6 +22,7 @@ export function useOrdifyChat(config: OrdifyConfig): UseOrdifyChatReturn {
   // Initialize API client
   if (!apiClientRef.current) {
     apiClientRef.current = new OrdifyApiClient({
+      publishableKey: config.publishableKey,
       apiKey: config.apiKey,
       apiBaseUrl: config.apiBaseUrl || 'https://api.ordify.ai',
       agentId: config.agentId

--- a/src/hooks/useOrdifyChat.ts
+++ b/src/hooks/useOrdifyChat.ts
@@ -15,9 +15,17 @@ export function useOrdifyChat(config: OrdifyConfig): UseOrdifyChatReturn {
   const [hasSessionStarted, setHasSessionStarted] = useState(false)
 
   const apiClientRef = useRef<OrdifyApiClient | null>(null)
+  const credFingerprintRef = useRef<string>('')
   const initialMessageSentRef = useRef(false)
   const historyLoadedRef = useRef(false)
   const isStreamingRef = useRef(false)
+
+  // Reset API client when credentials or endpoint change so stale clients are never used
+  const credFingerprint = `${config.publishableKey ?? ''}|${config.apiKey ?? ''}|${config.apiBaseUrl ?? ''}|${config.agentId}`
+  if (credFingerprintRef.current !== credFingerprint) {
+    apiClientRef.current = null
+    credFingerprintRef.current = credFingerprint
+  }
 
   // Initialize API client
   if (!apiClientRef.current) {

--- a/src/hooks/useOrdifyChat.ts
+++ b/src/hooks/useOrdifyChat.ts
@@ -1,7 +1,32 @@
-import { Message, OrdifyConfig, UseOrdifyChatReturn } from '@/types'
+import { AttachmentItem, Message, OrdifyConfig, UseOrdifyChatReturn } from '@/types'
 import { generateId } from '@/utils'
 import { OrdifyApiClient, parseStreamingResponse } from '@/utils/api'
 import { useCallback, useEffect, useRef, useState } from 'react'
+
+function messageMergeKey(msg: Message): string {
+  const att = (msg.attachments || []).map((a) => a.id).join('|')
+  return `${msg.role}:${msg.content.trim()}:${att}`
+}
+
+function mapAttachmentsFromHistory(msg: any): AttachmentItem[] | undefined {
+  const raw = msg.attachments
+  if (!raw || !Array.isArray(raw) || raw.length === 0) return undefined
+  const mapped: AttachmentItem[] = []
+  for (const a of raw) {
+    const url = a.url || ''
+    if (!url) continue
+    mapped.push({
+      id: a.id || generateId(),
+      name: String(a.name || 'attachment'),
+      type: a.type === 'image' ? 'image' : 'document',
+      url,
+      content_type: String(a.content_type || a.contentType || 'application/octet-stream'),
+      size: a.size,
+      preview: a.preview
+    })
+  }
+  return mapped.length ? mapped : undefined
+}
 
 export function useOrdifyChat(config: OrdifyConfig): UseOrdifyChatReturn {
   const [messages, setMessages] = useState<Message[]>([])
@@ -115,7 +140,8 @@ export function useOrdifyChat(config: OrdifyConfig): UseOrdifyChatReturn {
             content: msg.content || '',
             role: msg.role === 'assistant' ? 'assistant' : 'user',
             timestamp: msg.timestamp ? new Date(msg.timestamp) : new Date(),
-            sessionId: currentSessionId
+            sessionId: currentSessionId,
+            attachments: mapAttachmentsFromHistory(msg)
           }))
           // Merge with existing messages to preserve any messages added before history loaded
           // (e.g., user's quick question that was just sent)
@@ -128,8 +154,8 @@ export function useOrdifyChat(config: OrdifyConfig): UseOrdifyChatReturn {
               // First add existing messages (these are the most recent, like the user's question)
               prev.forEach(msg => {
                 messageMap.set(msg.id, msg)
-                // Also track by content+role to detect duplicates with different IDs
-                const contentKey = `${msg.role}:${msg.content.trim()}`
+                // Also track by content+role+attachments to detect duplicates with different IDs
+                const contentKey = messageMergeKey(msg)
                 if (!contentMap.has(contentKey)) {
                   contentMap.set(contentKey, msg)
                 }
@@ -137,7 +163,7 @@ export function useOrdifyChat(config: OrdifyConfig): UseOrdifyChatReturn {
 
               // Then add/update with loaded messages from server
               formattedMessages.forEach(msg => {
-                const contentKey = `${msg.role}:${msg.content.trim()}`
+                const contentKey = messageMergeKey(msg)
                 // Only add if we don't already have this message by ID or by content
                 if (!messageMap.has(msg.id) && !contentMap.has(contentKey)) {
                   messageMap.set(msg.id, msg)
@@ -183,21 +209,36 @@ export function useOrdifyChat(config: OrdifyConfig): UseOrdifyChatReturn {
     setError(null)
   }, [])
 
-  const sendMessage = useCallback(async (content: string, context?: string) => {
-    if (!content.trim() || isLoading) return
+  const uploadAttachment = useCallback(async (file: File) => {
+    if (!apiClientRef.current) {
+      throw new Error('API client not initialized')
+    }
+    return apiClientRef.current.uploadAttachment(file)
+  }, [])
+
+  const sendMessage = useCallback(
+    async (content: string, context?: string, attachments?: AttachmentItem[]) => {
+    const trimmed = content.trim()
+    const hasAttachments = Boolean(attachments && attachments.length > 0)
+    if ((!trimmed && !hasAttachments) || isLoading) return
 
     setIsLoading(true)
     setError(null)
 
     try {
+      const attachmentSnapshot = attachments?.length
+        ? attachments.map((a) => ({ ...a }))
+        : undefined
+
       // Add user message immediately - do this before setting hasSessionStarted
       // so the message is visible when the welcome screen disappears
       const userMessage: Message = {
         id: generateId(),
-        content: content.trim(),
+        content: trimmed,
         role: 'user',
         timestamp: new Date(),
-        sessionId: sessionId || undefined
+        sessionId: sessionId || undefined,
+        attachments: attachmentSnapshot
       }
 
 
@@ -234,7 +275,12 @@ export function useOrdifyChat(config: OrdifyConfig): UseOrdifyChatReturn {
 
       // Send message and handle streaming response
       isStreamingRef.current = true
-      const stream = await apiClientRef.current!.sendMessage(content.trim(), currentSessionId, context)
+      const stream = await apiClientRef.current!.sendMessage(
+        trimmed || '(see attachments)',
+        currentSessionId,
+        context,
+        attachmentSnapshot
+      )
       const reader = stream.getReader()
       const decoder = new TextDecoder()
 
@@ -303,7 +349,9 @@ export function useOrdifyChat(config: OrdifyConfig): UseOrdifyChatReturn {
       isStreamingRef.current = false
       setIsLoading(false)
     }
-  }, [config.onSessionCreated, config.onMessage, config.onError, isLoading, sessionId])
+  },
+  [config.onSessionCreated, config.onMessage, config.onError, config.sessionId, isLoading, sessionId]
+  )
 
   // Auto-send initial message on mount (only if no existing session or empty session)
   // Skip if quickQuestions are provided (user must select a question or type custom message)
@@ -354,6 +402,7 @@ export function useOrdifyChat(config: OrdifyConfig): UseOrdifyChatReturn {
   return {
     messages,
     sendMessage,
+    uploadAttachment,
     isLoading,
     error,
     clearError,

--- a/src/hooks/useOrdifyConfig.ts
+++ b/src/hooks/useOrdifyConfig.ts
@@ -5,6 +5,7 @@ export function useOrdifyConfig(config: OrdifyConfig) {
   return useMemo(() => {
     // Get configuration from props or environment variables
     const agentId = config.agentId || process.env.ORDIFY_AGENT_ID
+    const publishableKey = config.publishableKey || process.env.ORDIFY_PUBLISHABLE_KEY
     const apiKey = config.apiKey || process.env.ORDIFY_API_KEY
     const apiBaseUrl = config.apiBaseUrl || process.env.ORDIFY_API_BASE_URL || 'https://r.ordify.ai'
 
@@ -12,12 +13,15 @@ export function useOrdifyConfig(config: OrdifyConfig) {
       throw new Error('Ordify agent ID is required. Provide agentId prop or set ORDIFY_AGENT_ID environment variable.')
     }
 
-    if (!apiKey) {
-      throw new Error('Ordify API key is required. Provide apiKey prop or set ORDIFY_API_KEY environment variable.')
+    if (!publishableKey && !apiKey) {
+      throw new Error(
+        'Ordify credentials are required. Provide publishableKey (recommended) or apiKey.'
+      )
     }
 
     return {
       agentId,
+      publishableKey,
       apiKey,
       apiBaseUrl,
       mode: config.mode || 'floating',

--- a/src/hooks/useOrdifyConfig.ts
+++ b/src/hooks/useOrdifyConfig.ts
@@ -46,7 +46,11 @@ export function useOrdifyConfig(config: OrdifyConfig) {
       sessionId: config.sessionId,
       quickQuestions: config.quickQuestions,
       welcomeMessage: config.welcomeMessage,
-      welcomeImage: config.welcomeImage
+      welcomeImage: config.welcomeImage,
+      enableAttachments: config.enableAttachments,
+      maxAttachmentSizeMB: config.maxAttachmentSizeMB,
+      maxAttachments: config.maxAttachments,
+      allowedAttachmentTypes: config.allowedAttachmentTypes
     }
   }, [config])
 }

--- a/src/hooks/useWidgetAttachmentStaging.ts
+++ b/src/hooks/useWidgetAttachmentStaging.ts
@@ -1,0 +1,98 @@
+import { AttachmentItem, OrdifyConfig } from '@/types'
+import {
+  DEFAULT_WIDGET_ALLOWED_MIMES,
+  validateWidgetAttachmentFile
+} from '@/utils/attachments'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export function useWidgetAttachmentStaging(
+  config: OrdifyConfig,
+  uploadAttachment: (file: File) => Promise<AttachmentItem>
+) {
+  const maxBytes = (config.maxAttachmentSizeMB ?? 10) * 1024 * 1024
+  const maxFiles = config.maxAttachments ?? 3
+  const allowed = (
+    config.allowedAttachmentTypes?.length ? config.allowedAttachmentTypes : DEFAULT_WIDGET_ALLOWED_MIMES
+  ) as readonly string[]
+
+  const enabled = Boolean(config.enableAttachments && config.publishableKey)
+
+  const [staged, setStaged] = useState<AttachmentItem[]>([])
+  const [attachmentError, setAttachmentError] = useState<string | null>(null)
+  const stagedRef = useRef<AttachmentItem[]>([])
+
+  useEffect(() => {
+    stagedRef.current = staged
+  }, [staged])
+
+  const addFiles = useCallback(
+    async (files: File[]) => {
+      if (!enabled) return
+      setAttachmentError(null)
+      for (const file of files) {
+        if (stagedRef.current.length >= maxFiles) {
+          setAttachmentError(`At most ${maxFiles} attachments per message.`)
+          break
+        }
+        const err = validateWidgetAttachmentFile(file, maxBytes, allowed)
+        if (err) {
+          setAttachmentError(`${file.name}: ${err}`)
+          continue
+        }
+        try {
+          const item = await uploadAttachment(file)
+          setStaged((prev) => {
+            if (prev.length >= maxFiles) return prev
+            const next = [...prev, item]
+            stagedRef.current = next
+            return next
+          })
+        } catch (e) {
+          setAttachmentError(e instanceof Error ? e.message : 'Upload failed')
+        }
+      }
+    },
+    [allowed, enabled, maxBytes, maxFiles, uploadAttachment]
+  )
+
+  const removeStaged = useCallback((id: string) => {
+    setStaged((prev) => {
+      const next = prev.filter((a) => a.id !== id)
+      stagedRef.current = next
+      return next
+    })
+  }, [])
+
+  const clearStaged = useCallback(() => {
+    setStaged([])
+    stagedRef.current = []
+    setAttachmentError(null)
+  }, [])
+
+  const appendStaged = useCallback(
+    (item: AttachmentItem) => {
+      setAttachmentError(null)
+      setStaged((prev) => {
+        if (prev.length >= maxFiles) return prev
+        const next = [...prev, item]
+        stagedRef.current = next
+        return next
+      })
+    },
+    [maxFiles]
+  )
+
+  return {
+    enabled,
+    staged,
+    attachmentError,
+    setAttachmentError,
+    addFiles,
+    appendStaged,
+    removeStaged,
+    clearStaged,
+    maxFiles,
+    maxBytes,
+    allowed
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,10 +12,21 @@ export { MarkdownRenderer } from './components/MarkdownRenderer'
 // Hooks
 export { useOrdifyChat } from './hooks/useOrdifyChat'
 export { useOrdifyConfig } from './hooks/useOrdifyConfig'
+export { useWidgetAttachmentStaging } from './hooks/useWidgetAttachmentStaging'
 
 // Types
 export type {
-    Agent, ApiError, ChatRequest, Message, OrdifyApiClientConfig, OrdifyConfig, Session, StreamingResponse, UseOrdifyChatReturn
+    Agent,
+    ApiError,
+    AttachmentItem,
+    AttachmentWire,
+    ChatRequest,
+    Message,
+    OrdifyApiClientConfig,
+    OrdifyConfig,
+    Session,
+    StreamingResponse,
+    UseOrdifyChatReturn
 } from './types'
 
 // Utils

--- a/src/standalone.tsx
+++ b/src/standalone.tsx
@@ -10,6 +10,7 @@ function getDataConfig(script: HTMLScriptElement): Partial<OrdifyConfig> {
   const get = (key: string) => script.getAttribute(DATA_PREFIX + key)
   const config: Partial<OrdifyConfig> = {
     agentId: get('agent-id') ?? undefined,
+    publishableKey: get('publishable-key') ?? undefined,
     apiKey: get('api-key') ?? undefined,
     apiBaseUrl: get('api-base-url') ?? 'https://r.ordify.ai',
     mode: (get('mode') as OrdifyConfig['mode']) ?? 'floating',
@@ -41,9 +42,15 @@ function getDataConfig(script: HTMLScriptElement): Partial<OrdifyConfig> {
 }
 
 function mount(container: HTMLElement | null | undefined, config: OrdifyConfig): void {
-  if (!config.agentId || !config.apiKey) {
-    console.error('Ordify Chat Widget: agentId and apiKey are required.')
+  const hasCredential = Boolean(config.publishableKey || config.apiKey)
+  if (!config.agentId || !hasCredential) {
+    console.error('Ordify Chat Widget: agentId and publishableKey (or legacy apiKey) are required.')
     return
+  }
+  if (!config.publishableKey && config.apiKey) {
+    console.warn(
+      '[Ordify] Using legacy data-ordify-api-key. For production embeds, use data-ordify-publishable-key.'
+    )
   }
   const rootEl = container ?? (() => {
     const div = document.createElement('div')
@@ -59,8 +66,10 @@ function autoMount(): void {
   const scripts = document.querySelectorAll<HTMLScriptElement>(SCRIPT_SELECTOR)
   scripts.forEach((script) => {
     const config = getDataConfig(script)
-    if (!config.agentId || !config.apiKey) {
-      console.warn('Ordify Chat Widget: script tag missing data-ordify-agent-id or data-ordify-api-key. Skip auto-mount.')
+    if (!config.agentId || (!config.publishableKey && !config.apiKey)) {
+      console.warn(
+        'Ordify Chat Widget: script tag missing data-ordify-agent-id or credentials (data-ordify-publishable-key / data-ordify-api-key). Skip auto-mount.'
+      )
       return
     }
     const containerId = script.getAttribute(DATA_PREFIX + 'container-id')

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,7 +44,8 @@ export interface Agent {
 
 export interface OrdifyConfig {
   agentId: string
-  apiKey: string
+  apiKey?: string
+  publishableKey?: string
   apiBaseUrl?: string
   mode?: 'floating' | 'embedded'
   position?: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'
@@ -116,7 +117,8 @@ export interface ApiError {
 }
 
 export interface OrdifyApiClientConfig {
-  apiKey: string
+  apiKey?: string
+  publishableKey?: string
   apiBaseUrl: string
   agentId: string
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,11 +1,23 @@
 import { CSSProperties } from 'react'
 
+export interface AttachmentItem {
+  id: string
+  name: string
+  type: 'image' | 'document'
+  url: string
+  content_type: string
+  size?: number
+  /** Local data URL preview for images before upload completes */
+  preview?: string
+}
+
 export interface Message {
   id: string
   content: string
   role: 'user' | 'assistant'
   timestamp: Date
   sessionId?: string
+  attachments?: AttachmentItem[]
 }
 
 export interface Session {
@@ -87,11 +99,18 @@ export interface OrdifyConfig {
   quickQuestions?: string[]
   welcomeMessage?: string
   welcomeImage?: string
+  /** File attachments (requires publishableKey; uploads go to POST /widget/attachments) */
+  enableAttachments?: boolean
+  maxAttachmentSizeMB?: number
+  maxAttachments?: number
+  /** MIME types allowed client-side (server enforces its own list) */
+  allowedAttachmentTypes?: string[]
 }
 
 export interface UseOrdifyChatReturn {
   messages: Message[]
-  sendMessage: (content: string) => Promise<void>
+  sendMessage: (content: string, context?: string, attachments?: AttachmentItem[]) => Promise<void>
+  uploadAttachment: (file: File) => Promise<AttachmentItem>
   isLoading: boolean
   error: string | null
   clearError: () => void
@@ -127,6 +146,20 @@ export interface ChatRequest {
   message: string
   sessionId?: string
   context?: string
+  attachments?: AttachmentWire[]
+  use_document_understanding?: boolean
+}
+
+/** Wire shape for FastAPI AttachmentInfo (snake_case fields) */
+export interface AttachmentWire {
+  id?: string
+  name: string
+  url?: string | null
+  content_type: string
+  oauth_token?: string | null
+  size?: number | null
+  type?: string | null
+  preview?: string | null
 }
 
 export interface ChatResponse {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,15 +1,56 @@
-import { Agent, ApiError, ChatRequest, Message, OrdifyApiClientConfig, Session, StreamingResponse } from '@/types'
+import { ApiError, ChatRequest, Message, OrdifyApiClientConfig, Session, StreamingResponse } from '@/types'
 
 export class OrdifyApiClient {
   private config: OrdifyApiClientConfig
+  private warnedLegacyApiKey = false
 
   constructor(config: OrdifyApiClientConfig) {
     this.config = config
+    if (!this.config.publishableKey && !this.config.apiKey) {
+      throw new Error('Either publishableKey or apiKey is required.')
+    }
+    if (this.config.publishableKey && this.config.apiKey) {
+      console.warn('[Ordify] Both publishableKey and apiKey provided. publishableKey will be used.')
+    }
+  }
+
+  private usePublishableKey(): boolean {
+    return Boolean(this.config.publishableKey)
+  }
+
+  private maybeWarnLegacyApiKey(): void {
+    if (this.usePublishableKey() || this.warnedLegacyApiKey) {
+      return
+    }
+    this.warnedLegacyApiKey = true
+    console.warn(
+      '[Ordify] Using legacy apiKey in browser. For production embeds, use publishableKey from user settings.'
+    )
+  }
+
+  private getAuthHeaders(includeContentType = false): HeadersInit {
+    if (this.usePublishableKey()) {
+      return {
+        ...(includeContentType ? { 'Content-Type': 'application/json' } : {}),
+        'x-ordify-publishable-key': this.config.publishableKey as string,
+        'accept': 'application/json'
+      }
+    }
+
+    this.maybeWarnLegacyApiKey()
+    return {
+      ...(includeContentType ? { 'Content-Type': 'application/json' } : {}),
+      'api-key': this.config.apiKey as string,
+      'accept': 'application/json'
+    }
   }
 
   async sendMessage(content: string, sessionId?: string, context?: string): Promise<ReadableStream<Uint8Array>> {
-    const url = `${this.config.apiBaseUrl}/chat/agents/${this.config.agentId}`
-    
+    const path = this.usePublishableKey()
+      ? `/widget/chat/${this.config.agentId}`
+      : `/chat/agents/${this.config.agentId}`
+    const url = `${this.config.apiBaseUrl}${path}`
+
     const requestBody: ChatRequest = {
       message: content,
       sessionId: sessionId,
@@ -18,11 +59,7 @@ export class OrdifyApiClient {
 
     const response = await fetch(url, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'api-key': this.config.apiKey,
-        'accept': 'application/json'
-      },
+      headers: this.getAuthHeaders(true),
       body: JSON.stringify(requestBody)
     })
 
@@ -39,15 +76,12 @@ export class OrdifyApiClient {
   }
 
   async createSession(): Promise<Session> {
-    const url = `${this.config.apiBaseUrl}/sessions`
-    
+    const path = this.usePublishableKey() ? '/widget/sessions' : '/sessions'
+    const url = `${this.config.apiBaseUrl}${path}`
+
     const response = await fetch(url, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'api-key': this.config.apiKey,
-        'accept': 'application/json'
-      },
+      headers: this.getAuthHeaders(true),
       body: JSON.stringify({
         name: 'Chat Session',
         agentConfig: {
@@ -65,54 +99,15 @@ export class OrdifyApiClient {
     return response.json()
   }
 
-  async getAgents(): Promise<Agent[]> {
-    const url = `${this.config.apiBaseUrl}/chat/agents`
-    
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: {
-        'api-key': this.config.apiKey,
-        'accept': 'application/json'
-      }
-    })
-
-    if (!response.ok) {
-      const error: ApiError = await response.json()
-      throw new Error(`API Error: ${error.detail}`)
-    }
-
-    const data = await response.json()
-    return data.agents || []
-  }
-
-  async getSessions(): Promise<Session[]> {
-    const url = `${this.config.apiBaseUrl}/sessions`
-    
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: {
-        'api-key': this.config.apiKey,
-        'accept': 'application/json'
-      }
-    })
-
-    if (!response.ok) {
-      const error: ApiError = await response.json()
-      throw new Error(`API Error: ${error.detail}`)
-    }
-
-    return response.json()
-  }
-
   async getSessionWithMessages(sessionId: string): Promise<{ session: Session; messages: Message[] }> {
-    const url = `${this.config.apiBaseUrl}/sessions/${sessionId}/with-messages`
-    
+    const path = this.usePublishableKey()
+      ? `/widget/sessions/${sessionId}/with-messages`
+      : `/sessions/${sessionId}/with-messages`
+    const url = `${this.config.apiBaseUrl}${path}`
+
     const response = await fetch(url, {
       method: 'GET',
-      headers: {
-        'api-key': this.config.apiKey,
-        'accept': 'application/json'
-      }
+      headers: this.getAuthHeaders()
     })
 
     if (!response.ok) {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,4 +1,27 @@
-import { Agent, ApiError, ChatRequest, Message, OrdifyApiClientConfig, Session, StreamingResponse } from '@/types'
+import {
+  Agent,
+  ApiError,
+  AttachmentItem,
+  AttachmentWire,
+  ChatRequest,
+  Message,
+  OrdifyApiClientConfig,
+  Session,
+  StreamingResponse
+} from '@/types'
+
+function toAttachmentWire(a: AttachmentItem): AttachmentWire {
+  return {
+    id: a.id,
+    name: a.name,
+    url: a.url,
+    content_type: a.content_type,
+    type: a.type,
+    size: a.size ?? null,
+    preview: null,
+    oauth_token: null
+  }
+}
 
 export class OrdifyApiClient {
   private config: OrdifyApiClientConfig
@@ -45,16 +68,31 @@ export class OrdifyApiClient {
     }
   }
 
-  async sendMessage(content: string, sessionId?: string, context?: string): Promise<ReadableStream<Uint8Array>> {
+  async sendMessage(
+    content: string,
+    sessionId?: string,
+    context?: string,
+    attachments?: AttachmentItem[]
+  ): Promise<ReadableStream<Uint8Array>> {
     const path = this.usePublishableKey()
       ? `/widget/chat/${this.config.agentId}`
       : `/chat/agents/${this.config.agentId}`
     const url = `${this.config.apiBaseUrl}${path}`
 
+    const wires = attachments?.length ? attachments.map(toAttachmentWire) : undefined
+
     const requestBody: ChatRequest = {
       message: content,
       sessionId: sessionId,
       context: context
+    }
+    if (wires?.length) {
+      requestBody.attachments = wires
+      requestBody.use_document_understanding = wires.some(
+        (w) =>
+          w.type === 'document' ||
+          (!w.type && !String(w.content_type || '').startsWith('image/'))
+      )
     }
 
     const response = await fetch(url, {
@@ -73,6 +111,49 @@ export class OrdifyApiClient {
     }
 
     return response.body
+  }
+
+  /**
+   * Upload a file for widget chat. Requires publishableKey (browser-safe auth).
+   */
+  async uploadAttachment(file: File): Promise<AttachmentItem> {
+    if (!this.usePublishableKey()) {
+      throw new Error('[Ordify] uploadAttachment requires publishableKey.')
+    }
+    const url = `${this.config.apiBaseUrl}/widget/attachments`
+    const formData = new FormData()
+    formData.append('file', file)
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: this.getAuthHeaders(false),
+      body: formData
+    })
+
+    if (!response.ok) {
+      let detail = `HTTP ${response.status}`
+      try {
+        const err: ApiError = await response.json()
+        detail = err.detail || detail
+      } catch {
+        /* ignore */
+      }
+      throw new Error(`API Error: ${detail}`)
+    }
+
+    const data = (await response.json()) as AttachmentItem
+    if (!data?.url || !data?.content_type || !data?.name) {
+      throw new Error('Invalid attachment response from server')
+    }
+    return {
+      id: data.id,
+      name: data.name,
+      type: data.type === 'image' ? 'image' : 'document',
+      url: data.url,
+      content_type: data.content_type,
+      size: data.size,
+      preview: data.preview
+    }
   }
 
   async createSession(): Promise<Session> {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,4 +1,4 @@
-import { ApiError, ChatRequest, Message, OrdifyApiClientConfig, Session, StreamingResponse } from '@/types'
+import { Agent, ApiError, ChatRequest, Message, OrdifyApiClientConfig, Session, StreamingResponse } from '@/types'
 
 export class OrdifyApiClient {
   private config: OrdifyApiClientConfig
@@ -108,6 +108,47 @@ export class OrdifyApiClient {
     const response = await fetch(url, {
       method: 'GET',
       headers: this.getAuthHeaders()
+    })
+
+    if (!response.ok) {
+      const error: ApiError = await response.json()
+      throw new Error(`API Error: ${error.detail}`)
+    }
+
+    return response.json()
+  }
+
+  /** @deprecated Use the Ordify dashboard to list agents. Will be removed in a future major version. */
+  async getAgents(): Promise<Agent[]> {
+    if (!this.config.apiKey) {
+      throw new Error('[Ordify] getAgents() requires apiKey and is not supported with publishableKey.')
+    }
+    const url = `${this.config.apiBaseUrl}/chat/agents`
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { 'api-key': this.config.apiKey, 'accept': 'application/json' }
+    })
+
+    if (!response.ok) {
+      const error: ApiError = await response.json()
+      throw new Error(`API Error: ${error.detail}`)
+    }
+
+    const data = await response.json()
+    return data.agents || []
+  }
+
+  /** @deprecated Use sessionId prop to load sessions. Will be removed in a future major version. */
+  async getSessions(): Promise<Session[]> {
+    if (!this.config.apiKey) {
+      throw new Error('[Ordify] getSessions() requires apiKey and is not supported with publishableKey.')
+    }
+    const url = `${this.config.apiBaseUrl}/sessions`
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { 'api-key': this.config.apiKey, 'accept': 'application/json' }
     })
 
     if (!response.ok) {

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1,0 +1,62 @@
+/** Client-side allow list aligned with backend widget_attachments (subset for UX). */
+export const DEFAULT_WIDGET_ALLOWED_MIMES: readonly string[] = [
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-excel',
+  'text/csv',
+  'text/plain',
+  'text/markdown',
+  'application/json',
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif'
+]
+
+const EXT_TO_MIME: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.xls': 'application/vnd.ms-excel',
+  '.csv': 'text/csv',
+  '.txt': 'text/plain',
+  '.md': 'text/markdown',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif'
+}
+
+export function mimeFromFilename(name: string): string | undefined {
+  const i = name.lastIndexOf('.')
+  if (i < 0) return undefined
+  return EXT_TO_MIME[name.slice(i).toLowerCase()]
+}
+
+export async function filesFromDataTransfer(dt: DataTransfer | null): Promise<File[]> {
+  if (!dt) return []
+  const out: File[] = []
+  if (dt.files?.length) {
+    for (let i = 0; i < dt.files.length; i++) {
+      out.push(dt.files[i])
+    }
+  }
+  return out
+}
+
+export function validateWidgetAttachmentFile(
+  file: File,
+  maxBytes: number,
+  allowed: readonly string[]
+): string | null {
+  if (file.size > maxBytes) {
+    return `File too large (max ${Math.floor(maxBytes / (1024 * 1024))}MB)`
+  }
+  if (allowed.includes(file.type)) return null
+  const inferred = mimeFromFilename(file.name)
+  if (inferred && allowed.includes(inferred)) return null
+  return 'File type not allowed for attachments'
+}

--- a/static/wordpress-demo.html
+++ b/static/wordpress-demo.html
@@ -101,8 +101,12 @@
       <input id="agent-id" type="text" placeholder="Enter your Agent ID" />
     </div>
     <div class="field">
-      <label for="api-key">API Key *</label>
-      <input id="api-key" type="password" placeholder="Enter your API Key" />
+      <label for="publishable-key">Publishable Key *</label>
+      <input id="publishable-key" type="password" placeholder="Enter your pk_live_..." />
+    </div>
+    <div class="field">
+      <label for="api-key">API Key (legacy)</label>
+      <input id="api-key" type="password" placeholder="Optional legacy API key" />
     </div>
     <div class="field">
       <label for="api-base-url">API Base URL *</label>
@@ -121,9 +125,10 @@
 
     function getConfig() {
       var agentId = document.getElementById('agent-id').value.trim();
+      var publishableKey = document.getElementById('publishable-key').value.trim();
       var apiKey = document.getElementById('api-key').value.trim();
       var apiBaseUrl = document.getElementById('api-base-url').value.trim() || 'https://r.ordify.ai';
-      return { agentId: agentId, apiKey: apiKey, apiBaseUrl: apiBaseUrl };
+      return { agentId: agentId, publishableKey: publishableKey, apiKey: apiKey, apiBaseUrl: apiBaseUrl };
     }
 
     function loadSaved() {
@@ -132,6 +137,7 @@
         if (saved) {
           var c = JSON.parse(saved);
           document.getElementById('agent-id').value = c.agentId || '';
+          document.getElementById('publishable-key').value = c.publishableKey || '';
           document.getElementById('api-key').value = c.apiKey || '';
           document.getElementById('api-base-url').value = c.apiBaseUrl || 'https://r.ordify.ai';
           return c;
@@ -145,11 +151,12 @@
     }
 
     function mountWidget(config) {
-      if (!config.agentId || !config.apiKey) return;
+      if (!config.agentId || (!config.publishableKey && !config.apiKey)) return;
       var existing = document.getElementById(ROOT_ID);
       if (existing) existing.remove();
       OrdifyChatWidget.mount(null, {
         agentId: config.agentId,
+        publishableKey: config.publishableKey,
         apiKey: config.apiKey,
         apiBaseUrl: config.apiBaseUrl || 'https://r.ordify.ai',
         mode: 'floating',
@@ -161,8 +168,8 @@
 
     function onApply() {
       var config = getConfig();
-      if (!config.agentId || !config.apiKey) {
-        alert('Please enter Agent ID and API Key.');
+      if (!config.agentId || (!config.publishableKey && !config.apiKey)) {
+        alert('Please enter Agent ID and a Publishable Key (or legacy API Key).');
         return;
       }
       saveConfig(config);
@@ -171,7 +178,7 @@
 
     loadSaved();
     var saved = getConfig();
-    if (saved && saved.agentId && saved.apiKey) mountWidget(saved);
+    if (saved && saved.agentId && (saved.publishableKey || saved.apiKey)) mountWidget(saved);
 
     document.getElementById('apply-btn').addEventListener('click', onApply);
   </script>


### PR DESCRIPTION
## Widget Attachment Support

### Overview
This PR adds complete file attachment support to the Ordify chat widget, enabling users to upload documents and images when the widget is configured with a publishable key. The implementation includes drag-and-drop, attachment staging, visual chips, and full integration with the new `/widget/attachments` API.

### Key Features

- **Attachment Picker Component**
  - Paperclip button opens file picker with MIME filtering
  - Supports multiple file selection (up to configurable limit)
  - Disabled when no publishable key or attachments not enabled

- **Drag & Drop Support**
  - Users can drag files directly into conversation area
  - Visual drop feedback with cursor change

- **Attachment Staging**
  - Files upload immediately after selection (not on send)
  - Chips show uploaded files with remove buttons
  - Staged attachments sent with message when user submits

- **Message History**
  - User messages display attachment chips below text
  - Read-only mode for historical attachments
  - Server attachments mapped to frontend `AttachmentItem` type

- **Configurable Limits**
  - `enableAttachments`: Master toggle (requires publishableKey)
  - `maxAttachmentSizeMB`: Client-side size validation
  - `maxAttachments`: Max files per message
  - `allowedAttachmentTypes`: Optional MIME allow-list override

### New Components

| Component | Purpose |
|-----------|---------|
| `AttachmentPicker` | Button + file input with upload logic |
| `AttachmentChips` | Visual attachment list with remove button |
| `useWidgetAttachmentStaging` | Hook for staged attachment state management |

### API Integration

- New `uploadAttachment(file)` method on `useOrdifyChat`
- Uploads to `POST /widget/attachments` (requires publishable key)
- Returns `AttachmentItem` with URL for chat submission
- Chat sends `attachments` array when present

### Breaking Changes (none - backward compatible)

- Existing widgets without `enableAttachments` behave the same
- `apiKey` still works for legacy embeds (no file uploads)
- Publishable key required for attachment functionality

### Migration Notes

**For existing widget users:**
- Update to add `enableAttachments: true` to enable the feature
- Replace `apiKey` with `publishableKey` for attachment support
- Add GCS lifecycle rule for `widget_attachments/` prefix if using default bucket

**New configuration example:**
```tsx
<OrdifyChat
  agentId="your-agent-id"
  publishableKey="pk_live_..."
  enableAttachments={true}
  maxAttachmentSizeMB={10}
  maxAttachments={3}
/>
```

### Documentation Updates

- Updated README to emphasize publishable key over legacy API key
- Added attachment configuration examples
- Updated CHANGELOG with v1.0.45 changes

### Testing

- Upload flow: select → upload → staged chip → send → appears in message
- Drag & drop across all chat modes (floating, embedded, inline)
- Error handling: oversized files, invalid types, upload failures
- Rate limit errors displayed to user
- Staged attachments cleared after send
- Multiple attachments per message (up to limit)


**Closes:** AD-591