### PR TITLE
Feat/AD-591 Widget Attachment v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@ordify-ai/chat-widget",
-  "version": "1.0.40",
+  "name": "ordify-chat-widget",
+  "version": "1.0.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ordify-ai/chat-widget",
-      "version": "1.0.40",
+      "name": "ordify-chat-widget",
+      "version": "1.0.44",
       "license": "MIT",
       "dependencies": {
         "lucide-react": "^0.544.0",
@@ -15,6 +15,7 @@
         "use-stick-to-bottom": "^1.1.1"
       },
       "devDependencies": {
+        "@testing-library/react": "^14.2.1",
         "@types/node": "^20.0.0",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
@@ -31,6 +32,10 @@
         "vite": "^5.0.8",
         "vite-plugin-dts": "^3.6.4",
         "vitest": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       },
       "peerDependencies": {
         "react": "^18.0.0",
@@ -310,6 +315,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1768,10 +1783,91 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
+      "integrity": "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^9.0.0",
+        "@types/react-dom": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
       "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
       "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2409,6 +2505,33 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -2435,6 +2558,22 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2520,6 +2659,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2532,6 +2690,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -2816,12 +2991,81 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -2868,6 +3112,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2922,6 +3173,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-object-atoms": {
@@ -3370,6 +3642,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
@@ -3428,6 +3716,16 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3629,6 +3927,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3637,6 +3948,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -3821,6 +4145,102 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -3829,6 +4249,23 @@
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3860,6 +4297,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3868,6 +4318,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-path-inside": {
@@ -3887,6 +4354,54 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -3899,6 +4414,78 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4166,6 +4753,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -4382,6 +4979,67 @@
       "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -4607,6 +5265,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.49",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
@@ -4772,6 +5440,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -4911,6 +5600,24 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4953,6 +5660,40 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
@@ -4980,6 +5721,82 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -5051,6 +5868,20 @@
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -5718,6 +6549,67 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/why-is-node-running": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "use-stick-to-bottom": "^1.1.1"
   },
   "devDependencies": {
+    "@testing-library/react": "^14.2.1",
     "@types/node": "^20.0.0",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",

--- a/src/components/AttachmentPicker.tsx
+++ b/src/components/AttachmentPicker.tsx
@@ -21,7 +21,7 @@ const IconButton = styled.button`
   color: #374151;
   cursor: pointer;
   flex-shrink: 0;
-  transition: background 0.15s ease, border-color 0.15s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 
   &:hover:not(:disabled) {
     background: #f3f4f6;
@@ -40,8 +40,54 @@ const IconButton = styled.button`
   }
 `
 
+const IntegratedAttachButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+  min-height: 28px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: #64748b;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.2s ease, color 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background: rgba(15, 23, 42, 0.06);
+    color: #334155;
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    color: #94a3b8;
+
+    &:hover:not(:disabled) {
+      background: rgba(255, 255, 255, 0.08);
+      color: #e2e8f0;
+    }
+  }
+
+  [data-theme='dark'] & {
+    color: #94a3b8;
+
+    &:hover:not(:disabled) {
+      background: rgba(255, 255, 255, 0.08);
+      color: #e2e8f0;
+    }
+  }
+`
+
 interface AttachmentPickerProps {
   disabled?: boolean
+  integrated?: boolean
   maxFileBytes: number
   maxFiles: number
   allowedMime?: readonly string[]
@@ -53,6 +99,7 @@ interface AttachmentPickerProps {
 
 export function AttachmentPicker({
   disabled,
+  integrated = false,
   maxFileBytes,
   maxFiles,
   allowedMime = DEFAULT_WIDGET_ALLOWED_MIMES,
@@ -113,6 +160,7 @@ export function AttachmentPicker({
 
   const atLimit = currentCount >= maxFiles
   const isDisabled = Boolean(disabled || busy || atLimit)
+  const Btn = integrated ? IntegratedAttachButton : IconButton
 
   return (
     <>
@@ -124,15 +172,15 @@ export function AttachmentPicker({
         style={{ display: 'none' }}
         onChange={onInputChange}
       />
-      <IconButton
+      <Btn
         type="button"
         disabled={isDisabled}
         aria-label="Attach file"
         title="Attach file"
         onClick={() => inputRef.current?.click()}
       >
-        <Paperclip size={18} />
-      </IconButton>
+        <Paperclip size={16} strokeWidth={2} />
+      </Btn>
     </>
   )
 }

--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -26,6 +26,51 @@ const StyledStickToBottom = styled(StickToBottom)`
   flex: 1;
   overflow-y: auto;
   scroll-behavior: smooth;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(148, 163, 184, 0.55) transparent;
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: rgba(148, 163, 184, 0.45);
+    border-radius: 999px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(100, 116, 139, 0.55);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    scrollbar-color: rgba(71, 85, 105, 0.75) transparent;
+
+    &::-webkit-scrollbar-thumb {
+      background-color: rgba(71, 85, 105, 0.65);
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+      background-color: rgba(100, 116, 139, 0.75);
+    }
+  }
+
+  [data-theme='dark'] & {
+    scrollbar-color: rgba(71, 85, 105, 0.75) transparent;
+
+    &::-webkit-scrollbar-thumb {
+      background-color: rgba(71, 85, 105, 0.65);
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+      background-color: rgba(100, 116, 139, 0.75);
+    }
+  }
 `
 
 const StyledStickToBottomContent = styled(StickToBottom.Content)`

--- a/src/components/EmbeddedChat.tsx
+++ b/src/components/EmbeddedChat.tsx
@@ -14,9 +14,11 @@ import {
   ChatInput,
   ChatMessage,
   ChatWidget,
+  ComposerShell,
+  ComposerToolbar,
   ErrorMessage,
-  LoadingDots,
-  SendButton
+  ComposerSendButton,
+  LoadingDots
 } from './styled/ChatComponents'
 
 interface EmbeddedChatProps {
@@ -209,33 +211,43 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
                 )}
               </div>
             )}
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%' }}>
-              {attachmentsEnabled && (
-                <AttachmentPicker
+            <div style={{ width: '100%' }}>
+              <ComposerShell>
+                <ProfessionalInput
+                  ref={inputRef}
+                  variant="composer"
+                  value={inputValue}
+                  onChange={setInputValue}
+                  onKeyDown={handleKeyPress}
+                  placeholder={config.placeholder}
                   disabled={isLoading}
-                  maxFileBytes={maxBytes}
-                  maxFiles={maxFiles}
-                  allowedMime={allowed}
-                  currentCount={stagedAttachments.length}
-                  uploadAttachment={uploadAttachment}
-                  onUploaded={appendStaged}
-                  onError={setAttachmentError}
                 />
-              )}
-              <ProfessionalInput
-                ref={inputRef}
-                value={inputValue}
-                onChange={setInputValue}
-                onKeyDown={handleKeyPress}
-                placeholder={config.placeholder}
-                disabled={isLoading}
-              />
-              <SendButton
-                onClick={handleSendMessage}
-                disabled={isLoading || (!inputValue.trim() && stagedAttachments.length === 0)}
-              >
-                <SendIcon size={16} />
-              </SendButton>
+                <ComposerToolbar>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, minWidth: 0 }}>
+                    {attachmentsEnabled && (
+                      <AttachmentPicker
+                        integrated
+                        disabled={isLoading}
+                        maxFileBytes={maxBytes}
+                        maxFiles={maxFiles}
+                        allowedMime={allowed}
+                        currentCount={stagedAttachments.length}
+                        uploadAttachment={uploadAttachment}
+                        onUploaded={appendStaged}
+                        onError={setAttachmentError}
+                      />
+                    )}
+                  </div>
+                  <ComposerSendButton
+                    type="button"
+                    onClick={handleSendMessage}
+                    disabled={isLoading || (!inputValue.trim() && stagedAttachments.length === 0)}
+                    aria-label="Send message"
+                  >
+                    <SendIcon size={13} />
+                  </ComposerSendButton>
+                </ComposerToolbar>
+              </ComposerShell>
             </div>
           </ChatInput>
         </>

--- a/src/components/FloatingChat.tsx
+++ b/src/components/FloatingChat.tsx
@@ -13,14 +13,16 @@ import React from 'react'
 import { ChatHeader } from './ChatHeader'
 import {
   AgentAvatar,
-    ChatInput,
-    ChatMessage,
-    ChatWindow,
-    ErrorMessage,
-    FloatingButton,
-    LoadingDots,
-    SendButton,
-    ResizeHandle as StyledResizeHandle
+  ChatInput,
+  ChatMessage,
+  ChatWindow,
+  ComposerShell,
+  ComposerToolbar,
+  ErrorMessage,
+  FloatingButton,
+  ComposerSendButton,
+  LoadingDots,
+  ResizeHandle as StyledResizeHandle
 } from './styled/ChatComponents'
 
 interface FloatingChatProps {
@@ -256,33 +258,43 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
                 )}
               </div>
             )}
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%' }}>
-              {attachmentsEnabled && (
-                <AttachmentPicker
+            <div style={{ width: '100%' }}>
+              <ComposerShell>
+                <ProfessionalInput
+                  ref={inputRef}
+                  variant="composer"
+                  value={inputValue}
+                  onChange={setInputValue}
+                  onKeyDown={handleKeyPress}
+                  placeholder={config.placeholder}
                   disabled={isLoading}
-                  maxFileBytes={maxBytes}
-                  maxFiles={maxFiles}
-                  allowedMime={allowed}
-                  currentCount={stagedAttachments.length}
-                  uploadAttachment={uploadAttachment}
-                  onUploaded={appendStaged}
-                  onError={setAttachmentError}
                 />
-              )}
-              <ProfessionalInput
-                ref={inputRef}
-                value={inputValue}
-                onChange={setInputValue}
-                onKeyDown={handleKeyPress}
-                placeholder={config.placeholder}
-                disabled={isLoading}
-              />
-              <SendButton
-                onClick={handleSendMessage}
-                disabled={isLoading || (!inputValue.trim() && stagedAttachments.length === 0)}
-              >
-                <SendIcon size={16} />
-              </SendButton>
+                <ComposerToolbar>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, minWidth: 0 }}>
+                    {attachmentsEnabled && (
+                      <AttachmentPicker
+                        integrated
+                        disabled={isLoading}
+                        maxFileBytes={maxBytes}
+                        maxFiles={maxFiles}
+                        allowedMime={allowed}
+                        currentCount={stagedAttachments.length}
+                        uploadAttachment={uploadAttachment}
+                        onUploaded={appendStaged}
+                        onError={setAttachmentError}
+                      />
+                    )}
+                  </div>
+                  <ComposerSendButton
+                    type="button"
+                    onClick={handleSendMessage}
+                    disabled={isLoading || (!inputValue.trim() && stagedAttachments.length === 0)}
+                    aria-label="Send message"
+                  >
+                    <SendIcon size={13} />
+                  </ComposerSendButton>
+                </ComposerToolbar>
+              </ComposerShell>
             </div>
           </ChatInput>
         </>

--- a/src/components/InlineChat.tsx
+++ b/src/components/InlineChat.tsx
@@ -14,9 +14,11 @@ import {
   ChatInput,
   ChatMessage,
   ChatWidget,
+  ComposerShell,
+  ComposerToolbar,
   ErrorMessage,
-  LoadingDots,
-  SendButton
+  ComposerSendButton,
+  LoadingDots
 } from './styled/ChatComponents'
 
 interface InlineChatProps {
@@ -174,33 +176,43 @@ export function InlineChat({ config, chat }: InlineChatProps) {
                 )}
               </div>
             )}
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%' }}>
-              {attachmentsEnabled && (
-                <AttachmentPicker
+            <div style={{ width: '100%' }}>
+              <ComposerShell>
+                <ProfessionalInput
+                  ref={inputRef}
+                  variant="composer"
+                  value={inputValue}
+                  onChange={setInputValue}
+                  onKeyDown={handleKeyPress}
+                  placeholder={config.placeholder}
                   disabled={isLoading}
-                  maxFileBytes={maxBytes}
-                  maxFiles={maxFiles}
-                  allowedMime={allowed}
-                  currentCount={stagedAttachments.length}
-                  uploadAttachment={uploadAttachment}
-                  onUploaded={appendStaged}
-                  onError={setAttachmentError}
                 />
-              )}
-              <ProfessionalInput
-                ref={inputRef}
-                value={inputValue}
-                onChange={setInputValue}
-                onKeyDown={handleKeyPress}
-                placeholder={config.placeholder}
-                disabled={isLoading}
-              />
-              <SendButton
-                onClick={handleSendMessage}
-                disabled={isLoading || (!inputValue.trim() && stagedAttachments.length === 0)}
-              >
-                <SendIcon size={16} />
-              </SendButton>
+                <ComposerToolbar>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, minWidth: 0 }}>
+                    {attachmentsEnabled && (
+                      <AttachmentPicker
+                        integrated
+                        disabled={isLoading}
+                        maxFileBytes={maxBytes}
+                        maxFiles={maxFiles}
+                        allowedMime={allowed}
+                        currentCount={stagedAttachments.length}
+                        uploadAttachment={uploadAttachment}
+                        onUploaded={appendStaged}
+                        onError={setAttachmentError}
+                      />
+                    )}
+                  </div>
+                  <ComposerSendButton
+                    type="button"
+                    onClick={handleSendMessage}
+                    disabled={isLoading || (!inputValue.trim() && stagedAttachments.length === 0)}
+                    aria-label="Send message"
+                  >
+                    <SendIcon size={13} />
+                  </ComposerSendButton>
+                </ComposerToolbar>
+              </ComposerShell>
             </div>
           </ChatInput>
         </>

--- a/src/components/ProfessionalInput.tsx
+++ b/src/components/ProfessionalInput.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
-import { ProfessionalInput as StyledProfessionalInput } from './styled/ChatComponents'
+import {
+  ComposerInnerInput,
+  ProfessionalInput as StyledProfessionalInput,
+} from './styled/ChatComponents'
 
 interface ProfessionalInputProps {
   value: string
@@ -9,6 +12,7 @@ interface ProfessionalInputProps {
   disabled?: boolean
   className?: string
   maxLength?: number
+  variant?: 'default' | 'composer'
 }
 
 export const ProfessionalInput = React.forwardRef<HTMLTextAreaElement, ProfessionalInputProps>(function ProfessionalInput({
@@ -18,7 +22,8 @@ export const ProfessionalInput = React.forwardRef<HTMLTextAreaElement, Professio
   placeholder = "Type a message...",
   disabled = false,
   className,
-  maxLength = 2000
+  maxLength = 2000,
+  variant = 'default',
 }, ref) {
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     onChange(e.target.value)
@@ -34,8 +39,10 @@ export const ProfessionalInput = React.forwardRef<HTMLTextAreaElement, Professio
     }
   }
 
+  const InputEl = variant === 'composer' ? ComposerInnerInput : StyledProfessionalInput
+
   return (
-    <StyledProfessionalInput
+    <InputEl
       ref={ref}
       value={value}
       onChange={handleChange}
@@ -47,7 +54,8 @@ export const ProfessionalInput = React.forwardRef<HTMLTextAreaElement, Professio
       onInput={(e) => {
         const target = e.target as HTMLTextAreaElement
         target.style.height = 'auto'
-        target.style.height = `${Math.min(target.scrollHeight, 120)}px`
+        const cap = variant === 'composer' ? 96 : 120
+        target.style.height = `${Math.min(target.scrollHeight, cap)}px`
       }}
     />
   )

--- a/src/components/styled/ChatComponents.tsx
+++ b/src/components/styled/ChatComponents.tsx
@@ -84,12 +84,114 @@ export const ChatMessage = styled.div<{ $isUser: boolean }>`
   }
 `
 
+export const ComposerShell = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  background-color: #ffffff;
+  overflow: hidden;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &:focus-within {
+    border-color: #9ca3af;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    background-color: #18181b;
+    border-color: rgba(255, 255, 255, 0.1);
+
+    &:focus-within {
+      border-color: rgba(255, 255, 255, 0.3);
+    }
+  }
+
+  [data-theme='dark'] & {
+    background-color: #18181b;
+    border-color: rgba(255, 255, 255, 0.1);
+
+    &:focus-within {
+      border-color: rgba(255, 255, 255, 0.3);
+    }
+  }
+`
+
+export const ComposerToolbar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  flex-shrink: 0;
+  padding: 6px 10px;
+  border-top: 1px solid #e5e7eb;
+  background-color: #f9fafb;
+
+  @media (prefers-color-scheme: dark) {
+    border-top-color: #52525b;
+    background-color: #3f3f46;
+  }
+
+  [data-theme='dark'] & {
+    border-top-color: #52525b;
+    background-color: #3f3f46;
+  }
+`
+
+export const ComposerInnerInput = styled.textarea`
+  display: block;
+  width: 100%;
+  min-width: 0;
+  min-height: 42px;
+  max-height: 96px;
+  padding: 8px 12px;
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
+  color: #1f2937;
+  font-size: 14px;
+  line-height: 1.5;
+  font-family: inherit;
+  resize: none;
+  outline: none;
+  transition: color 0.2s ease;
+  box-sizing: border-box;
+  overflow-y: auto;
+
+  &::placeholder {
+    color: #6b7280;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    color: #f9fafb;
+
+    &::placeholder {
+      color: #9ca3af;
+    }
+  }
+
+  [data-theme='dark'] & {
+    color: #f9fafb;
+
+    &::placeholder {
+      color: #9ca3af;
+    }
+  }
+`
+
 // Chat input container
 export const ChatInput = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 12px;
+  padding: 8px 12px 10px;
   border-top: 1px solid #e5e7eb;
   background-color: #ffffff;
   
@@ -235,6 +337,103 @@ export const SendButton = styled.button`
       background: #2563eb;
       color: white;
     }
+    &:disabled {
+      border-color: #6b7280;
+      color: #6b7280;
+    }
+  }
+`
+
+export const ComposerSendButton = styled.button`
+  width: 26px;
+  height: 26px;
+  min-width: 26px;
+  min-height: 26px;
+  padding: 0;
+  box-sizing: border-box;
+  line-height: normal;
+  background: transparent;
+  border: 1px solid #3b82f6;
+  border-radius: 8px;
+  color: #3b82f6;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease;
+  flex-shrink: 0;
+
+  &:hover:not(:disabled) {
+    background: rgba(59, 130, 246, 0.12);
+    color: #2563eb;
+    border-color: #2563eb;
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px rgba(59, 130, 246, 0.45);
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    border-color: #9ca3af;
+    color: #9ca3af;
+  }
+
+  svg {
+    width: 13px !important;
+    height: 13px !important;
+    min-width: 13px !important;
+    min-height: 13px !important;
+    color: inherit;
+    display: block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+    flex-shrink: 0;
+  }
+
+  svg path {
+    stroke: currentColor !important;
+    fill: none !important;
+    visibility: visible !important;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    border-color: #60a5fa;
+    color: #60a5fa;
+
+    &:hover:not(:disabled) {
+      background: rgba(96, 165, 250, 0.14);
+      color: #93c5fd;
+      border-color: #93c5fd;
+    }
+
+    &:focus-visible {
+      box-shadow: 0 0 0 2px #18181b, 0 0 0 4px rgba(96, 165, 250, 0.45);
+    }
+
+    &:disabled {
+      border-color: #6b7280;
+      color: #6b7280;
+    }
+  }
+
+  [data-theme='dark'] & {
+    border-color: #60a5fa;
+    color: #60a5fa;
+
+    &:hover:not(:disabled) {
+      background: rgba(96, 165, 250, 0.14);
+      color: #93c5fd;
+      border-color: #93c5fd;
+    }
+
+    &:focus-visible {
+      box-shadow: 0 0 0 2px #18181b, 0 0 0 4px rgba(96, 165, 250, 0.45);
+    }
+
     &:disabled {
       border-color: #6b7280;
       color: #6b7280;

--- a/src/hooks/useWidgetAttachmentStaging.test.tsx
+++ b/src/hooks/useWidgetAttachmentStaging.test.tsx
@@ -1,0 +1,105 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { OrdifyConfig } from '@/types'
+import { useWidgetAttachmentStaging } from './useWidgetAttachmentStaging'
+
+function pngFile(size = 100) {
+  return new File([new Uint8Array(size)], 'x.png', { type: 'image/png' })
+}
+
+describe('useWidgetAttachmentStaging', () => {
+  it('is disabled without publishableKey even when enableAttachments is true', async () => {
+    const upload = vi.fn()
+    const config: OrdifyConfig = {
+      agentId: 'a',
+      apiKey: 'legacy',
+      enableAttachments: true,
+    }
+    const { result } = renderHook(() =>
+      useWidgetAttachmentStaging(config, upload),
+    )
+    expect(result.current.enabled).toBe(false)
+    await act(async () => {
+      await result.current.addFiles([pngFile()])
+    })
+    expect(upload).not.toHaveBeenCalled()
+  })
+
+  it('is disabled when publishableKey is set but enableAttachments is false', () => {
+    const upload = vi.fn()
+    const config: OrdifyConfig = {
+      agentId: 'a',
+      publishableKey: 'pk_live_x',
+      enableAttachments: false,
+    }
+    const { result } = renderHook(() =>
+      useWidgetAttachmentStaging(config, upload),
+    )
+    expect(result.current.enabled).toBe(false)
+  })
+
+  it('is enabled when publishableKey and enableAttachments are set', () => {
+    const upload = vi.fn()
+    const config: OrdifyConfig = {
+      agentId: 'a',
+      publishableKey: 'pk_live_x',
+      enableAttachments: true,
+    }
+    const { result } = renderHook(() =>
+      useWidgetAttachmentStaging(config, upload),
+    )
+    expect(result.current.enabled).toBe(true)
+  })
+
+  it('calls uploadAttachment per valid file when enabled', async () => {
+    const item = {
+      id: '1',
+      name: 'x.png',
+      type: 'image' as const,
+      url: 'https://x',
+      content_type: 'image/png',
+    }
+    const upload = vi.fn().mockResolvedValue(item)
+    const config: OrdifyConfig = {
+      agentId: 'a',
+      publishableKey: 'pk_live_x',
+      enableAttachments: true,
+      maxAttachments: 3,
+    }
+    const { result } = renderHook(() =>
+      useWidgetAttachmentStaging(config, upload),
+    )
+    await act(async () => {
+      await result.current.addFiles([pngFile()])
+    })
+    expect(upload).toHaveBeenCalledTimes(1)
+    expect(result.current.staged).toHaveLength(1)
+    expect(result.current.staged[0].id).toBe('1')
+  })
+
+  it('sets attachmentError when max files exceeded', async () => {
+    const item = {
+      id: '1',
+      name: 'x.png',
+      type: 'image' as const,
+      url: 'https://x',
+      content_type: 'image/png',
+    }
+    const upload = vi.fn().mockResolvedValue(item)
+    const config: OrdifyConfig = {
+      agentId: 'a',
+      publishableKey: 'pk_live_x',
+      enableAttachments: true,
+      maxAttachments: 1,
+    }
+    const { result } = renderHook(() =>
+      useWidgetAttachmentStaging(config, upload),
+    )
+    await act(async () => {
+      await result.current.addFiles([pngFile(10), pngFile(20)])
+    })
+    expect(upload).toHaveBeenCalledTimes(1)
+    expect(result.current.staged).toHaveLength(1)
+    expect(result.current.attachmentError).toMatch(/At most 1/)
+  })
+})

--- a/src/utils/api.uploadAttachment.test.ts
+++ b/src/utils/api.uploadAttachment.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { OrdifyApiClient } from './api'
+
+describe('OrdifyApiClient.uploadAttachment', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('throws when only apiKey is configured', async () => {
+    const client = new OrdifyApiClient({
+      agentId: 'agent-1',
+      apiKey: 'secret',
+      apiBaseUrl: 'http://localhost:5001',
+    })
+    const file = new File(['%PDF'], 'doc.pdf', { type: 'application/pdf' })
+    await expect(client.uploadAttachment(file)).rejects.toThrow(
+      /publishableKey/,
+    )
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('POSTs FormData to /widget/attachments with publishable key header', async () => {
+    const body = {
+      id: 'att-1',
+      name: 'doc.pdf',
+      type: 'document',
+      url: 'https://storage.example/o/doc.pdf',
+      content_type: 'application/pdf',
+      size: 4,
+    }
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const client = new OrdifyApiClient({
+      agentId: 'agent-1',
+      publishableKey: 'pk_live_test',
+      apiBaseUrl: 'http://localhost:5001',
+    })
+    const file = new File(['%PDF'], 'doc.pdf', { type: 'application/pdf' })
+    const item = await client.uploadAttachment(file)
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const call = vi.mocked(fetch).mock.calls[0]
+    const url = String(call[0])
+    const init = call[1] as {
+      method?: string
+      headers?: Record<string, string>
+      body?: FormData
+    }
+    expect(url).toBe('http://localhost:5001/widget/attachments')
+    expect(init.method).toBe('POST')
+    expect(init.headers).toMatchObject({
+      'x-ordify-publishable-key': 'pk_live_test',
+      accept: 'application/json',
+    })
+    expect(init.body).toBeInstanceOf(FormData)
+    expect(item.id).toBe('att-1')
+    expect(item.url).toBe(body.url)
+    expect(item.content_type).toBe('application/pdf')
+    expect(item.type).toBe('document')
+  })
+
+  it('throws with API detail on non-OK response', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'quota exceeded' }), {
+        status: 429,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const client = new OrdifyApiClient({
+      agentId: 'agent-1',
+      publishableKey: 'pk_live_test',
+      apiBaseUrl: 'http://localhost:5001',
+    })
+    const file = new File(['x'], 'a.png', { type: 'image/png' })
+    await expect(client.uploadAttachment(file)).rejects.toThrow(
+      /quota exceeded/,
+    )
+  })
+})

--- a/src/utils/attachments.test.ts
+++ b/src/utils/attachments.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_WIDGET_ALLOWED_MIMES,
+  mimeFromFilename,
+  validateWidgetAttachmentFile,
+} from './attachments'
+
+describe('validateWidgetAttachmentFile', () => {
+  const maxBytes = 10 * 1024 * 1024
+  const allowed = DEFAULT_WIDGET_ALLOWED_MIMES
+
+  it('accepts allowed MIME by file.type', () => {
+    const f = new File([new Uint8Array(100)], 'x.png', { type: 'image/png' })
+    expect(validateWidgetAttachmentFile(f, maxBytes, allowed)).toBeNull()
+  })
+
+  it('accepts allowed MIME inferred from extension when type empty', () => {
+    const f = new File([new Uint8Array(100)], 'doc.pdf', { type: '' })
+    expect(validateWidgetAttachmentFile(f, maxBytes, allowed)).toBeNull()
+  })
+
+  it('rejects oversize files', () => {
+    const f = new File([new Uint8Array(maxBytes + 1)], 'big.png', {
+      type: 'image/png',
+    })
+    expect(validateWidgetAttachmentFile(f, maxBytes, allowed)).toMatch(
+      /File too large/,
+    )
+  })
+
+  it('rejects disallowed types', () => {
+    const f = new File([new Uint8Array(10)], 'x.exe', {
+      type: 'application/octet-stream',
+    })
+    expect(validateWidgetAttachmentFile(f, maxBytes, allowed)).toMatch(
+      /not allowed/,
+    )
+  })
+
+  it('respects custom allowedAttachmentTypes list', () => {
+    const f = new File([new Uint8Array(10)], 'x.txt', { type: 'text/plain' })
+    expect(
+      validateWidgetAttachmentFile(f, maxBytes, ['application/pdf']),
+    ).toMatch(/not allowed/)
+  })
+})
+
+describe('mimeFromFilename', () => {
+  it('maps known extensions', () => {
+    expect(mimeFromFilename('a.PDF')).toBe('application/pdf')
+    expect(mimeFromFilename('b.JPEG')).toBe('image/jpeg')
+  })
+
+  it('returns undefined without extension', () => {
+    expect(mimeFromFilename('noext')).toBeUndefined()
+  })
+})

--- a/vite.standalone.config.ts
+++ b/vite.standalone.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   plugins: [react()],
   build: {
+    emptyOutDir: false,
     lib: {
       entry: resolve(__dirname, 'src/standalone.tsx'),
       name: 'OrdifyChatWidget',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,17 @@
 import react from '@vitejs/plugin-react'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
   test: {
     environment: 'jsdom',
   },


### PR DESCRIPTION
## Summary

Adds optional **file attachments** to the Ordify chat widget (pick, stage, validate, upload, and send with messages), with **configurable limits** (count, size, MIME allowlist), **drag-and-drop** support in chat surfaces, and **publishable-key–oriented** docs and API usage. Includes **demo/test page** improvements and **Vitest** coverage for staging and upload helpers.

## Why

Customers embedding the widget need to send documents and images with chat messages while staying within safe size/type limits and working cleanly with **publishable keys** and the widget API.

## What changed

### Attachments

- Extended `OrdifyConfig` / types for attachment toggles and limits (`enabled`, `maxFiles`, `maxFileBytes`, allowed MIME types, etc.).
- New UI: `AttachmentPicker`, `AttachmentChips`; integrated into `FloatingChat`, `EmbeddedChat`, and `InlineChat` with staging before send.
- `useWidgetAttachmentStaging` for limits, validation, and staged state; drag-and-drop on the conversation surface where enabled.
- `useOrdifyChat` updated to include attachments when sending messages.
- Utilities: file validation, MIME/size checks, helpers used by picker and drop flows.
- `utils/api` extended for upload/message flows needed by attachments (plus tests).

### API client & credentials

- Documentation and examples emphasize **`publishableKey`** for browser embeds; legacy `apiKey` called out where relevant.
- Restored **`getAgents` / `getSessions`** on `OrdifyApiClient` as **`@deprecated`** shims for backward compatibility (clear errors when used without a suitable key / no widget equivalents).
- **`useOrdifyChat`**: recreate API client when `publishableKey`, `apiKey`, `apiBaseUrl`, or `agentId` changes so credentials never go stale after mount.

### Quality

- **Vitest**: `useWidgetAttachmentStaging` tests; upload attachment API tests; attachment validation tests.
- **Standalone build**: `vite.standalone.config` adjusted so standalone output does not wipe the library **`dist/`** (`emptyOutDir: false`).
- **Demo**: `demo.tsx` / static demo HTML updates for attachment behavior and testing.

### Docs & packaging

- **README**, integration examples, **CHANGELOG** updated for attachment configuration and publishable key usage.

## How to test

1. `npm install && npm run build && npm test -- --run` in `ordify-chat-widget`.
2. Run `npm run dev` and use the demo page: enable attachments in config, attach files within limits, send with text-only and text + files; confirm chips and errors for over-limit / bad MIME.
3. Smoke standalone bundle if you ship `ordify-chat-widget.standalone.js`.

## Risk / rollout

- **Breaking**: none intended; deprecated methods throw if misused without keys.
- **Config**: hosts must set attachment-related options explicitly where defaults are not enough.

**Jira:** AD-591
