### PR TITLE
Feat/AD-591 Widget attachment v2 and browser-safe config

### DIFF
--- a/src/hooks/useOrdifyConfig.ts
+++ b/src/hooks/useOrdifyConfig.ts
@@ -1,13 +1,21 @@
 import { OrdifyConfig } from '@/types'
 import { useMemo } from 'react'
 
+function readOrdifyEnv(name: string): string | undefined {
+  if (typeof process === 'undefined' || !process.env) {
+    return undefined
+  }
+  const v = (process.env as Record<string, string | undefined>)[name]
+  return typeof v === 'string' && v.length > 0 ? v : undefined
+}
+
 export function useOrdifyConfig(config: OrdifyConfig) {
   return useMemo(() => {
-    // Get configuration from props or environment variables
-    const agentId = config.agentId || process.env.ORDIFY_AGENT_ID
-    const publishableKey = config.publishableKey || process.env.ORDIFY_PUBLISHABLE_KEY
-    const apiKey = config.apiKey || process.env.ORDIFY_API_KEY
-    const apiBaseUrl = config.apiBaseUrl || process.env.ORDIFY_API_BASE_URL || 'https://r.ordify.ai'
+    const agentId = config.agentId || readOrdifyEnv('ORDIFY_AGENT_ID')
+    const publishableKey = config.publishableKey || readOrdifyEnv('ORDIFY_PUBLISHABLE_KEY')
+    const apiKey = config.apiKey || readOrdifyEnv('ORDIFY_API_KEY')
+    const apiBaseUrl =
+      config.apiBaseUrl || readOrdifyEnv('ORDIFY_API_BASE_URL') || 'https://r.ordify.ai'
 
     if (!agentId) {
       throw new Error('Ordify agent ID is required. Provide agentId prop or set ORDIFY_AGENT_ID environment variable.')


### PR DESCRIPTION
## Summary

Adds widget file attachment support (staging, upload, configurable limits/types) and fixes `useOrdifyConfig` so **browser/embed builds do not reference bare `process`** when props omit credentials (prevents `ReferenceError: process is not defined` on WordPress/unpkg/IIFE).

## Changes (high level)

- File attachment flow for publishable-key widget usage; tests for attachments upload/staging hooks.
- Standalone/Vite build compatibility: safe env reads via `readOrdifyEnv()` in `useOrdifyConfig.ts`.
- Related demo/test page and input UX adjustments.

## Testing

- `npm run test` / vitest passes locally.

## Related

- AD-591

## Checklist

- [ ] Review standalone bundle (`npm run build:standalone`) on a host without Node `process`.
- [ ] After merge: bump/publish npm package if consuming apps use unpkg/CDN.