### PR TITLE
feat(AD-611): widget copy and PDF export actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "ordify-chat-widget",
-  "version": "1.0.44",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ordify-chat-widget",
-      "version": "1.0.44",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
+        "dompurify": "^3.4.2",
         "lucide-react": "^0.544.0",
         "markdown-to-jsx": "^7.7.13",
         "styled-components": "^6.1.19",
@@ -1981,6 +1982,13 @@
       "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
@@ -3119,6 +3127,15 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ordify-chat-widget",
-  "version": "1.0.48",
+  "version": "1.1.0",
   "description": "A professional React chat widget for integrating Ordify AI agents into applications with minimal setup.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
@@ -66,6 +66,7 @@
     "react-dom": "^18.0.0"
   },
   "dependencies": {
+    "dompurify": "^3.4.2",
     "lucide-react": "^0.544.0",
     "markdown-to-jsx": "^7.7.13",
     "styled-components": "^6.1.19",

--- a/src/components/AssistantMessageActions.tsx
+++ b/src/components/AssistantMessageActions.tsx
@@ -1,0 +1,96 @@
+import { copyToClipboard } from '@/utils/copyToClipboard'
+import { Copy, FileDown } from 'lucide-react'
+import React from 'react'
+import styled from 'styled-components'
+
+const ActionRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 6px;
+  padding-left: 2px;
+`
+
+const IconButton = styled.button`
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: #6b7280;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background: #f3f4f6;
+    color: #111827;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  [data-theme='dark'] & {
+    color: #9ca3af;
+
+    &:hover:not(:disabled) {
+      background: #3f3f46;
+      color: #f9fafb;
+    }
+  }
+`
+
+export interface AssistantMessageActionsProps {
+  content: string
+  disabled: boolean
+  onExportPdf: (content: string) => Promise<void>
+}
+
+export function AssistantMessageActions({
+  content,
+  disabled,
+  onExportPdf
+}: AssistantMessageActionsProps) {
+  const [pdfBusy, setPdfBusy] = React.useState(false)
+
+  const handleCopy = () => {
+    void copyToClipboard(content)
+  }
+
+  const handlePdf = async () => {
+    setPdfBusy(true)
+    try {
+      await onExportPdf(content)
+    } finally {
+      setPdfBusy(false)
+    }
+  }
+
+  return (
+    <ActionRow>
+      <IconButton
+        type="button"
+        onClick={handleCopy}
+        disabled={disabled}
+        aria-label="Copy message"
+        title="Copy"
+      >
+        <Copy size={16} strokeWidth={1.75} />
+      </IconButton>
+      <IconButton
+        type="button"
+        onClick={() => void handlePdf()}
+        disabled={disabled || pdfBusy}
+        aria-label="Download PDF"
+        title="Download PDF"
+      >
+        <FileDown size={16} strokeWidth={1.75} />
+      </IconButton>
+    </ActionRow>
+  )
+}

--- a/src/components/EmbeddedChat.tsx
+++ b/src/components/EmbeddedChat.tsx
@@ -1,3 +1,4 @@
+import { AssistantMessageActions } from '@/components/AssistantMessageActions'
 import { AttachmentChips } from '@/components/AttachmentChips'
 import { AttachmentPicker } from '@/components/AttachmentPicker'
 import { MarkdownRenderer } from '@/components/MarkdownRenderer'
@@ -5,6 +6,7 @@ import { ProfessionalInput } from '@/components/ProfessionalInput'
 import { WelcomeScreen } from '@/components/WelcomeScreen'
 import { useWidgetAttachmentStaging } from '@/hooks/useWidgetAttachmentStaging'
 import { OrdifyConfig, UseOrdifyChatReturn } from '@/types'
+import { shouldShowAssistantActions } from '@/utils/assistantMessageActions'
 import { filesFromDataTransfer } from '@/utils/attachments'
 import { SendIcon } from './SendIcon'
 import React from 'react'
@@ -27,7 +29,15 @@ interface EmbeddedChatProps {
 }
 
 export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
-  const { messages, sendMessage, uploadAttachment, isLoading, error, hasSessionStarted } = chat
+  const {
+    messages,
+    sendMessage,
+    uploadAttachment,
+    exportMessagePdf,
+    isLoading,
+    error,
+    hasSessionStarted
+  } = chat
   const [inputValue, setInputValue] = React.useState('')
   const [isDarkMode, setIsDarkMode] = React.useState(false)
   const inputRef = React.useRef<HTMLTextAreaElement>(null)
@@ -157,18 +167,36 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
                       $size="28px"
                     />
                   )}
-                  <ChatMessage $isUser={message.role === 'user'}>
-                    {message.role === 'assistant' ? (
-                      <MarkdownRenderer content={message.content} />
-                    ) : (
+                  {message.role === 'assistant' ? (
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'flex-start',
+                        maxWidth: '80%'
+                      }}
+                    >
+                      <ChatMessage $isUser={false}>
+                        <MarkdownRenderer content={message.content} />
+                      </ChatMessage>
+                      {shouldShowAssistantActions(message, messages, isLoading) && (
+                        <AssistantMessageActions
+                          content={message.content}
+                          disabled={isLoading}
+                          onExportPdf={(c) => exportMessagePdf(c)}
+                        />
+                      )}
+                    </div>
+                  ) : (
+                    <ChatMessage $isUser={true}>
                       <>
                         {message.attachments && message.attachments.length > 0 && (
                           <AttachmentChips attachments={message.attachments} readOnly />
                         )}
                         {message.content ? message.content : null}
                       </>
-                    )}
-                  </ChatMessage>
+                    </ChatMessage>
+                  )}
                 </div>
               ))}
 

--- a/src/components/FloatingChat.tsx
+++ b/src/components/FloatingChat.tsx
@@ -1,3 +1,4 @@
+import { AssistantMessageActions } from '@/components/AssistantMessageActions'
 import { AttachmentChips } from '@/components/AttachmentChips'
 import { AttachmentPicker } from '@/components/AttachmentPicker'
 import { Conversation, ConversationContent } from '@/components/Conversation'
@@ -6,6 +7,7 @@ import { ProfessionalInput } from '@/components/ProfessionalInput'
 import { WelcomeScreen } from '@/components/WelcomeScreen'
 import { useWidgetAttachmentStaging } from '@/hooks/useWidgetAttachmentStaging'
 import { OrdifyConfig, UseOrdifyChatReturn } from '@/types'
+import { shouldShowAssistantActions } from '@/utils/assistantMessageActions'
 import { filesFromDataTransfer } from '@/utils/attachments'
 import { MessageSquareIcon } from './Icons'
 import { SendIcon } from './SendIcon'
@@ -31,7 +33,17 @@ interface FloatingChatProps {
 }
 
 export function FloatingChat({ config, chat }: FloatingChatProps) {
-  const { messages, sendMessage, uploadAttachment, isLoading, error, isOpen, setIsOpen, hasSessionStarted } = chat
+  const {
+    messages,
+    sendMessage,
+    uploadAttachment,
+    exportMessagePdf,
+    isLoading,
+    error,
+    isOpen,
+    setIsOpen,
+    hasSessionStarted
+  } = chat
   const [inputValue, setInputValue] = React.useState('')
   const [chatHeight, setChatHeight] = React.useState<number | string>(config.height || 600)
   const [isDarkMode, setIsDarkMode] = React.useState(false)
@@ -204,18 +216,36 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
                       $size="28px"
                     />
                   )}
-                   <ChatMessage $isUser={message.role === 'user'}>
-                    {message.role === 'assistant' ? (
-                      <MarkdownRenderer content={message.content} />
-                    ) : (
+                  {message.role === 'assistant' ? (
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'flex-start',
+                        maxWidth: '80%'
+                      }}
+                    >
+                      <ChatMessage $isUser={false}>
+                        <MarkdownRenderer content={message.content} />
+                      </ChatMessage>
+                      {shouldShowAssistantActions(message, messages, isLoading) && (
+                        <AssistantMessageActions
+                          content={message.content}
+                          disabled={isLoading}
+                          onExportPdf={(c) => exportMessagePdf(c)}
+                        />
+                      )}
+                    </div>
+                  ) : (
+                    <ChatMessage $isUser={true}>
                       <>
                         {message.attachments && message.attachments.length > 0 && (
                           <AttachmentChips attachments={message.attachments} readOnly />
                         )}
                         {message.content ? message.content : null}
                       </>
-                    )}
-                  </ChatMessage>
+                    </ChatMessage>
+                  )}
                 </div>
               ))}
 

--- a/src/demo.tsx
+++ b/src/demo.tsx
@@ -1,9 +1,20 @@
+/* eslint-disable react-refresh/only-export-components -- Vite demo entry */
 import { useEffect, useState } from 'react'
 import ReactDOM from 'react-dom/client'
 import { OrdifyChat } from './components/OrdifyChat'
+import { OrdifyApiClient } from '@/utils/api'
 
 const STORAGE_KEY = 'ordify-demo-config'
 const SESSION_STORAGE_KEY = 'ordify-demo-sessions'
+
+const PDF_MARKDOWN_SAMPLE = `# PDF sample
+
+- First item
+- Second item
+
+**Bold** and \`inline code\`.`
+
+const PDF_HTML_SAMPLE = `<!DOCTYPE html><html><body><p>PDF HTML sample</p><ul><li>A</li><li>B</li></ul></body></html>`
 
 function DemoApp() {
   const [agentId, setAgentId] = useState("")
@@ -111,6 +122,10 @@ function DemoApp() {
     typeof window !== 'undefined' ? Math.max(400, window.innerHeight * 0.6) : 600
   )
 
+  const [pdfSampleContent, setPdfSampleContent] = useState(PDF_MARKDOWN_SAMPLE)
+  const [pdfBusy, setPdfBusy] = useState(false)
+  const [pdfStatus, setPdfStatus] = useState<string | null>(null)
+
   useEffect(() => {
     if (useDynamicHeight && typeof window !== 'undefined') {
       const updateHeight = () => {
@@ -192,12 +207,46 @@ function DemoApp() {
       : {}),
   }
 
+  const runPdfSmokeTest = async () => {
+    if (!publishableKey && !apiKey) {
+      setPdfStatus('Add a publishable key or API key in Configuration.')
+      return
+    }
+    if (!agentId.trim()) {
+      setPdfStatus('Agent ID is required.')
+      return
+    }
+    if (!pdfSampleContent.trim()) {
+      setPdfStatus('Paste content or load a sample.')
+      return
+    }
+    setPdfBusy(true)
+    setPdfStatus(null)
+    try {
+      const client = new OrdifyApiClient({
+        agentId,
+        apiBaseUrl,
+        publishableKey: publishableKey || undefined,
+        apiKey: apiKey || undefined
+      })
+      await client.exportMessagePdf(pdfSampleContent.trim(), 'ordify-demo-export.pdf')
+      setPdfStatus('PDF download started. Check your downloads folder.')
+    } catch (e) {
+      setPdfStatus(e instanceof Error ? e.message : 'PDF export failed.')
+    } finally {
+      setPdfBusy(false)
+    }
+  }
+
   return (
     <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
       <h1>Ordify Chat Widget Test</h1>
       <p>
-        Testing the initialContext feature, button configurability, auto-scroll, and optional file
-        attachments (publishable key + backend <code>/widget/attachments</code>).
+        Tests initial context, button options, auto-scroll, attachments (<code>/widget/attachments</code>),
+        assistant message <strong>Copy</strong> and <strong>PDF</strong> actions, and{' '}
+        <code>POST /document-conversion/pdf</code> via the smoke test below. Run the API on{' '}
+        <strong>API Base URL</strong> (for example <code>http://localhost:5001</code>) with widget-compatible
+        CORS for this origin.
       </p>
 
       {/* Configuration Section */}
@@ -597,6 +646,99 @@ function DemoApp() {
         </div>
       </div>
 
+      <div
+        style={{
+          marginBottom: '30px',
+          padding: '20px',
+          border: '2px solid #e0e0e0',
+          borderRadius: '8px',
+          backgroundColor: '#ffffff'
+        }}
+      >
+        <h2 style={{ marginTop: 0 }}>Copy and PDF export</h2>
+        <p style={{ color: '#666', fontSize: '14px', marginBottom: '12px' }}>
+          <strong>In the widgets:</strong> After the assistant finishes a reply, use Copy or PDF under the
+          message (hidden while the reply is still streaming).
+        </p>
+        <p style={{ color: '#666', fontSize: '14px', marginBottom: '16px' }}>
+          <strong>API smoke test:</strong> Calls <code>POST /document-conversion/pdf</code> with your saved
+          keys. The server chooses markdown vs HTML from the payload (<code>input_format: auto</code> default).
+        </p>
+        <label style={{ display: 'block', marginBottom: '6px', fontWeight: 'bold' }}>
+          Sample assistant content
+        </label>
+        <textarea
+          value={pdfSampleContent}
+          onChange={(e) => setPdfSampleContent(e.target.value)}
+          style={{
+            width: '100%',
+            maxWidth: '720px',
+            minHeight: '140px',
+            padding: '8px',
+            border: '1px solid #ccc',
+            borderRadius: '4px',
+            fontFamily: 'monospace',
+            fontSize: '13px',
+            resize: 'vertical'
+          }}
+          spellCheck={false}
+        />
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px', alignItems: 'center', marginTop: '12px' }}>
+          <button
+            type="button"
+            onClick={() => {
+              setPdfSampleContent(PDF_MARKDOWN_SAMPLE)
+              setPdfStatus(null)
+            }}
+            style={{
+              padding: '8px 14px',
+              backgroundColor: '#0f766e',
+              color: 'white',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: 'pointer'
+            }}
+          >
+            Load markdown sample
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setPdfSampleContent(PDF_HTML_SAMPLE)
+              setPdfStatus(null)
+            }}
+            style={{
+              padding: '8px 14px',
+              backgroundColor: '#0369a1',
+              color: 'white',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: 'pointer'
+            }}
+          >
+            Load HTML sample
+          </button>
+          <button
+            type="button"
+            onClick={() => void runPdfSmokeTest()}
+            disabled={pdfBusy || (!publishableKey && !apiKey)}
+            style={{
+              padding: '8px 14px',
+              backgroundColor: pdfBusy || (!publishableKey && !apiKey) ? '#94a3b8' : '#7c3aed',
+              color: 'white',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: pdfBusy || (!publishableKey && !apiKey) ? 'not-allowed' : 'pointer'
+            }}
+          >
+            {pdfBusy ? 'Downloading…' : 'Download PDF (API smoke test)'}
+          </button>
+        </div>
+        {pdfStatus && (
+          <p style={{ marginTop: '12px', fontSize: '14px', color: '#334155' }}>{pdfStatus}</p>
+        )}
+      </div>
+
       {/* Interactive Testing Controls */}
       <div style={{
         marginBottom: '30px',
@@ -605,7 +747,7 @@ function DemoApp() {
         borderRadius: '8px',
         backgroundColor: '#f9f9f9'
       }}>
-        <h2>🧪 Interactive Testing Controls</h2>
+        <h2>Interactive testing controls</h2>
 
         <div style={{ marginBottom: '15px' }}>
           <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>
@@ -752,6 +894,9 @@ function DemoApp() {
                 <h2 style={{ margin: 0 }}>Test 1: Floating Widget</h2>
                 <p style={{ margin: '5px 0' }}>Button should show: "?"</p>
                 <p style={{ margin: '5px 0' }}>Auto-scroll should work when new messages arrive</p>
+                <p style={{ margin: '5px 0', fontSize: '13px', color: '#444' }}>
+                  After an assistant reply completes, Copy and PDF appear under that message.
+                </p>
               </div>
               {floatingSessionId && (
                 <div style={{
@@ -828,6 +973,9 @@ function DemoApp() {
                 <h2 style={{ margin: 0 }}>Test 2: Embedded Chat</h2>
                 <p style={{ margin: '5px 0' }}>Auto-scroll should work when new messages arrive</p>
                 <p style={{ margin: '5px 0' }}>Widget should be embedded as a full-page chat interface</p>
+                <p style={{ margin: '5px 0', fontSize: '13px', color: '#444' }}>
+                  Same Copy and PDF actions under assistant messages when not streaming.
+                </p>
               </div>
               {embeddedSessionId && (
                 <div style={{

--- a/src/hooks/useOrdifyChat.ts
+++ b/src/hooks/useOrdifyChat.ts
@@ -226,6 +226,13 @@ export function useOrdifyChat(config: OrdifyConfig): UseOrdifyChatReturn {
     return apiClientRef.current.uploadAttachment(file)
   }, [])
 
+  const exportMessagePdf = useCallback(async (content: string, filename?: string) => {
+    if (!apiClientRef.current) {
+      throw new Error('API client not initialized')
+    }
+    await apiClientRef.current.exportMessagePdf(content, filename)
+  }, [])
+
   const sendMessage = useCallback(
     async (content: string, context?: string, attachments?: AttachmentItem[]) => {
     const trimmed = content.trim()
@@ -415,6 +422,7 @@ export function useOrdifyChat(config: OrdifyConfig): UseOrdifyChatReturn {
     messages,
     sendMessage,
     uploadAttachment,
+    exportMessagePdf,
     isLoading,
     error,
     clearError,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -111,6 +111,7 @@ export interface UseOrdifyChatReturn {
   messages: Message[]
   sendMessage: (content: string, context?: string, attachments?: AttachmentItem[]) => Promise<void>
   uploadAttachment: (file: File) => Promise<AttachmentItem>
+  exportMessagePdf: (content: string, filename?: string) => Promise<void>
   isLoading: boolean
   error: string | null
   clearError: () => void

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -9,7 +9,6 @@ import {
   Session,
   StreamingResponse
 } from '@/types'
-
 function toAttachmentWire(a: AttachmentItem): AttachmentWire {
   return {
     id: a.id,
@@ -51,7 +50,7 @@ export class OrdifyApiClient {
     )
   }
 
-  private getAuthHeaders(includeContentType = false): HeadersInit {
+  private getAuthHeaders(includeContentType = false): Record<string, string> {
     if (this.usePublishableKey()) {
       return {
         ...(includeContentType ? { 'Content-Type': 'application/json' } : {}),
@@ -66,6 +65,83 @@ export class OrdifyApiClient {
       'api-key': this.config.apiKey as string,
       'accept': 'application/json'
     }
+  }
+
+  private getAuthHeadersForPdfExport(): Record<string, string> {
+    if (this.usePublishableKey()) {
+      return {
+        'Content-Type': 'application/json',
+        'x-ordify-publishable-key': this.config.publishableKey as string,
+        accept: 'application/pdf'
+      }
+    }
+    this.maybeWarnLegacyApiKey()
+    return {
+      'Content-Type': 'application/json',
+      'api-key': this.config.apiKey as string,
+      accept: 'application/pdf'
+    }
+  }
+
+  /**
+   * Export message content as PDF via POST /document-conversion/pdf (publishable or api-key auth).
+   */
+  async exportMessagePdf(content: string, filename?: string): Promise<void> {
+    const url = `${this.config.apiBaseUrl}/document-conversion/pdf`
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: this.getAuthHeadersForPdfExport(),
+      body: JSON.stringify({
+        content,
+        filename: filename ?? undefined,
+        format: 'A4',
+        margin_top: '1cm',
+        margin_bottom: '1cm',
+        margin_left: '1cm',
+        margin_right: '1cm',
+        print_background: true,
+        display_header_footer: false
+      })
+    })
+
+    if (!response.ok) {
+      let detail = `HTTP ${response.status}`
+      try {
+        const err = (await response.json()) as ApiError
+        detail = typeof err.detail === 'string' ? err.detail : detail
+      } catch {
+        try {
+          const t = await response.text()
+          if (t) detail = t.slice(0, 500)
+        } catch {
+          /* ignore */
+        }
+      }
+      throw new Error(`PDF export failed: ${detail}`)
+    }
+
+    const blob = await response.blob()
+    const dispo = response.headers.get('Content-Disposition')
+    let downloadName = filename?.endsWith('.pdf') ? filename : `${filename ?? 'document'}.pdf`
+    const m = /filename\*?=(?:UTF-8''|")?([^";\n]+)/i.exec(dispo ?? '')
+    if (m?.[1]) {
+      try {
+        downloadName = decodeURIComponent(m[1].replace(/^"|"$/g, '').trim())
+      } catch {
+        downloadName = m[1].replace(/^"|"$/g, '').trim()
+      }
+    }
+    if (!downloadName.endsWith('.pdf')) downloadName += '.pdf'
+
+    const objectUrl = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = objectUrl
+    a.download = downloadName
+    a.rel = 'noopener noreferrer'
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(objectUrl)
   }
 
   async sendMessage(

--- a/src/utils/assistantMessageActions.ts
+++ b/src/utils/assistantMessageActions.ts
@@ -1,0 +1,13 @@
+import type { Message } from '@/types'
+
+export function shouldShowAssistantActions(
+  message: Message,
+  messages: Message[],
+  isLoading: boolean
+): boolean {
+  if (message.role !== 'assistant' || !message.content.trim()) return false
+  const last = messages[messages.length - 1]
+  if (!last) return true
+  if (isLoading && last.role === 'assistant' && last.id === message.id) return false
+  return true
+}

--- a/src/utils/copyToClipboard.ts
+++ b/src/utils/copyToClipboard.ts
@@ -1,0 +1,22 @@
+export async function copyToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return
+    } catch {
+      /* fallback below */
+    }
+  }
+  const ta = document.createElement('textarea')
+  ta.value = text
+  ta.setAttribute('readonly', '')
+  ta.style.position = 'fixed'
+  ta.style.left = '-9999px'
+  document.body.appendChild(ta)
+  ta.select()
+  try {
+    document.execCommand('copy')
+  } finally {
+    document.body.removeChild(ta)
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,7 +16,7 @@ export function debounce<T extends (...args: any[]) => any>(
   func: T,
   wait: number
 ): (...args: Parameters<T>) => void {
-  let timeout: NodeJS.Timeout
+  let timeout: ReturnType<typeof setTimeout>
   return (...args: Parameters<T>) => {
     clearTimeout(timeout)
     timeout = setTimeout(() => func(...args), wait)


### PR DESCRIPTION
## Summary

Adds an **assistant-only action row** under each assistant bubble in **floating** and **embedded** chat modes: **copy** (raw message text) and **download PDF** (via `POST /document-conversion/pdf` using the same auth model as the rest of the widget).

## Copy button

- **New component:** `AssistantMessageActions` renders a compact row (`styled-components`) with two icon buttons; copy uses **Lucide** `Copy` (16px).
- **Behavior:** Copies **`message.content` as stored** (Markdown/source text), not the rendered HTML from `MarkdownRenderer`. That keeps clipboard output aligned with “what we sent to PDF” and avoids DOM scraping.
- **Implementation:** `copyToClipboard()` (`src/utils/copyToClipboard.ts`) tries **`navigator.clipboard.writeText`** first, then falls back to a hidden **`textarea` + `document.execCommand('copy')`** for older / restricted contexts (e.g. some embeds).
- **A11y:** Copy control uses **`aria-label="Copy message"`** and **`title="Copy"`**.

## Download PDF button

- **UI:** Second icon uses Lucide **`FileDown`**; **`aria-label="Download PDF"`** / **`title="Download PDF"`**.
- **Loading state:** While a PDF request is in flight, local **`pdfBusy`** disables the PDF button (copy stays enabled unless the row is globally disabled—see below). Prevents double downloads.
- **API:** `OrdifyApiClient.exportMessagePdf` (`src/utils/api.ts`):
  - **`POST {apiBaseUrl}/document-conversion/pdf`**
  - Headers: existing widget auth (**`x-ordify-publishable-key`** preferred, legacy **`api-key`** fallback), **`Accept: application/pdf`**, **`Content-Type: application/json`**
  - Body includes **`content`**, optional **`filename`**, A4 + 1cm margins, **`print_background: true`**, **`display_header_footer: false`**. **`input_format` is omitted** so the backend uses its **`auto`** detection (markdown-first for typical assistant text).
  - On success: reads **`Content-Disposition`** when present to name the file; otherwise defaults to **`document.pdf`**; triggers download via **blob URL + temporary `<a download>`**.
  - On error: surfaces **`detail`** from JSON when possible, else truncated response text.

## Hook & types

- **`useOrdifyChat`** exposes **`exportMessagePdf(content, filename?)`**, delegating to `OrdifyApiClient`.
- **`UseOrdifyChatReturn`** includes **`exportMessagePdf`** for consumers/tests.

## Where it appears

- **`EmbeddedChat`** and **`FloatingChat`:** After each assistant `ChatMessage`, when **`shouldShowAssistantActions(message, messages, isLoading)`** is true (`src/utils/assistantMessageActions.ts`):
  - Only **`role === 'assistant'`** and non-empty **`content`**.
  - **Hidden** for the **currently streaming** assistant message (last message is assistant, **`isLoading`**, same **`message.id`**) so copy/PDF do not show until the turn finishes.
- **`disabled={isLoading}`** on the action row disables both icons while any send/stream cycle is active (reduces races with partial content).

## Demo / QA

- **`demo.tsx`** includes sample markdown/HTML strings for manual PDF checks against a local API base URL (developer convenience).

## Dependencies

- **`lucide-react`** added for consistent SVG icons (copy / download) without emoji.

## How to test

1. Configure publishable key + agent + API base in the widget demo or host app.
2. Send a message; after the assistant reply completes, confirm **copy** puts full assistant text on the clipboard.
3. Confirm **PDF** downloads; verify filename from **`Content-Disposition`** when the API sets it.
4. While the assistant is still streaming, confirm the action row is **not** shown for that bubble.
5. Repeat in **embedded** and **floating** modes.

## Related

- **Backend PR:** `POST /document-conversion/pdf` (same ticket / coordinated deploy).