### PR TITLE
refactor: unify dark mode styling approach across components

### DIFF
--- a/src/components/AttachmentPicker.tsx
+++ b/src/components/AttachmentPicker.tsx
@@ -66,15 +66,6 @@ const IntegratedAttachButton = styled.button`
     cursor: not-allowed;
   }
 
-  @media (prefers-color-scheme: dark) {
-    color: #94a3b8;
-
-    &:hover:not(:disabled) {
-      background: rgba(255, 255, 255, 0.08);
-      color: #e2e8f0;
-    }
-  }
-
   [data-theme='dark'] & {
     color: #94a3b8;
 

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -34,22 +34,6 @@ const HeaderContainer = styled.div<{ $primaryColor?: string; $showWelcomeScreen?
   border-bottom: none;
   transition: background-color 0.3s ease, color 0.3s ease;
 
-  @media (prefers-color-scheme: dark) {
-    background: ${props => {
-      if (props.$showWelcomeScreen && props.$primaryColor) {
-        return props.$primaryColor;
-      }
-      return '#1f2937';
-    }};
-    color: ${props => {
-      if (props.$showWelcomeScreen && props.$primaryColor) {
-        return 'white';
-      }
-      return '#f9fafb';
-    }};
-    border-bottom: none;
-  }
-  
   [data-theme="dark"] & {
     background: ${props => {
       if (props.$showWelcomeScreen && props.$primaryColor) {

--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -51,18 +51,6 @@ const StyledStickToBottom = styled(StickToBottom)<{ $surfaceTheme: 'light' | 'da
     background-color: rgba(100, 116, 139, 0.55);
   }
 
-  @media (prefers-color-scheme: dark) {
-    scrollbar-color: rgba(71, 85, 105, 0.75) transparent;
-
-    &::-webkit-scrollbar-thumb {
-      background-color: rgba(71, 85, 105, 0.65);
-    }
-
-    &::-webkit-scrollbar-thumb:hover {
-      background-color: rgba(100, 116, 139, 0.75);
-    }
-  }
-
   [data-theme='dark'] & {
     scrollbar-color: rgba(71, 85, 105, 0.75) transparent;
 
@@ -109,7 +97,7 @@ const ScrollButton = styled.button`
     height: 16px;
   }
 
-  @media (prefers-color-scheme: dark) {
+  [data-theme='dark'] & {
     background: #1f2937;
     border-color: #374151;
     color: #9ca3af;

--- a/src/components/InlineChat.tsx
+++ b/src/components/InlineChat.tsx
@@ -45,6 +45,30 @@ export function InlineChat({ config, chat }: InlineChatProps) {
     allowed
   } = useWidgetAttachmentStaging(config, uploadAttachment)
 
+  const [isDarkMode, setIsDarkMode] = React.useState(false)
+
+  const getThemeValue = () => {
+    if (config.theme === 'dark') return 'dark'
+    if (config.theme === 'light') return 'light'
+    return isDarkMode ? 'dark' : 'light'
+  }
+
+  React.useEffect(() => {
+    if (config.theme === 'auto' || !config.theme) {
+      const checkDarkMode = () => {
+        setIsDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches)
+      }
+
+      checkDarkMode()
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+      mediaQuery.addEventListener('change', checkDarkMode)
+
+      return () => mediaQuery.removeEventListener('change', checkDarkMode)
+    } else {
+      setIsDarkMode(config.theme === 'dark')
+    }
+  }, [config.theme])
+
   const handleSendMessage = async () => {
     const trimmed = inputValue.trim()
     if ((!trimmed && stagedAttachments.length === 0) || isLoading) return
@@ -81,13 +105,11 @@ export function InlineChat({ config, chat }: InlineChatProps) {
 
   return (
     <ChatWidget
-      data-theme="light"
+      data-theme={getThemeValue()}
       style={{
         height: config.height,
         display: 'flex',
         flexDirection: 'column',
-        backgroundColor: 'white',
-        border: '1px solid #e5e7eb',
         borderRadius: '8px'
       }}
     >
@@ -103,7 +125,12 @@ export function InlineChat({ config, chat }: InlineChatProps) {
         />
       ) : (
         <>
-          <Conversation style={{ flex: 1 }} surfaceTheme="light" onDragOver={onDragOver} onDrop={onDrop}>
+          <Conversation
+            style={{ flex: 1 }}
+            surfaceTheme={getThemeValue()}
+            onDragOver={onDragOver}
+            onDrop={onDrop}
+          >
             <ConversationContent>
               {messages.map(message => (
                 <div

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -1,43 +1,42 @@
 import Markdown from 'markdown-to-jsx'
+import React from 'react'
 import styled from 'styled-components'
 
 const MarkdownContainer = styled.div`
-  code {
-    @media (prefers-color-scheme: dark) {
-      background-color: #374151 !important;
-      color: #e5e7eb !important;
-    }
-    
-    [data-theme="dark"] & {
-      background-color: #374151 !important;
-      color: #e5e7eb !important;
-    }
+  overflow-wrap: anywhere;
+
+  > *:first-child {
+    margin-top: 0 !important;
   }
-  
-  pre {
-    @media (prefers-color-scheme: dark) {
-      background-color: #374151 !important;
-      color: #e5e7eb !important;
-    }
-    
-    [data-theme="dark"] & {
-      background-color: #374151 !important;
-      color: #e5e7eb !important;
-    }
+
+  > *:last-child {
+    margin-bottom: 0 !important;
   }
-  
-  blockquote {
-    @media (prefers-color-scheme: dark) {
-      background-color: #1e3a8a !important;
-      border-left-color: #3b82f6 !important;
-      color: #e5e7eb !important;
-    }
-    
-    [data-theme="dark"] & {
-      background-color: #1e3a8a !important;
-      border-left-color: #3b82f6 !important;
-      color: #e5e7eb !important;
-    }
+
+  [data-theme='dark'] & code {
+    background-color: #374151 !important;
+    color: #e5e7eb !important;
+  }
+
+  [data-theme='dark'] & pre {
+    background-color: #374151 !important;
+    color: #e5e7eb !important;
+  }
+
+  [data-theme='dark'] & blockquote {
+    background-color: #1e3a8a !important;
+    border-left-color: #3b82f6 !important;
+    color: #e5e7eb !important;
+  }
+
+  [data-theme='dark'] & table th,
+  [data-theme='dark'] & table td {
+    border-color: #4b5563 !important;
+  }
+
+  [data-theme='dark'] & table th {
+    background-color: #374151 !important;
+    color: #f9fafb !important;
   }
 `
 
@@ -46,18 +45,79 @@ interface MarkdownRendererProps {
   className?: string
 }
 
+const listUlStyle: React.CSSProperties = {
+  marginTop: 0,
+  marginBottom: '12px',
+  paddingLeft: '20px',
+  listStyleType: 'disc',
+  listStylePosition: 'outside',
+  lineHeight: 1.5
+}
+
+const listOlStyle: React.CSSProperties = {
+  marginTop: 0,
+  marginBottom: '12px',
+  paddingLeft: '20px',
+  listStyleType: 'decimal',
+  listStylePosition: 'outside',
+  lineHeight: 1.5
+}
+
+const listLiStyle: React.CSSProperties = {
+  marginBottom: '4px',
+  lineHeight: 1.5,
+  color: 'inherit'
+}
+
+const headingMargin = (fontSize: string): React.CSSProperties => ({
+  fontSize,
+  fontWeight: 700,
+  marginTop: '16px',
+  marginBottom: '8px',
+  color: 'inherit'
+})
+
+function MarkdownTable({
+  children,
+  ...rest
+}: React.PropsWithChildren<React.HTMLAttributes<HTMLTableElement>>) {
+  return (
+    <div
+      style={{
+        display: 'block',
+        overflowX: 'auto',
+        marginBottom: '12px',
+        maxWidth: '100%',
+        WebkitOverflowScrolling: 'touch'
+      }}
+    >
+      <table
+        {...rest}
+        style={{
+          borderCollapse: 'collapse',
+          width: '100%',
+          fontSize: 'inherit',
+          color: 'inherit'
+        }}
+      >
+        {children}
+      </table>
+    </div>
+  )
+}
+
 export function MarkdownRenderer({ content, className }: MarkdownRendererProps) {
   return (
     <MarkdownContainer className={className}>
       <Markdown
         options={{
           overrides: {
-            // Custom styling for markdown elements with better spacing
             p: {
               props: {
-                style: { 
+                style: {
+                  marginTop: 0,
                   marginBottom: '12px',
-                  lineHeight: '1.5',
+                  lineHeight: 1.5,
                   color: 'inherit'
                 }
               }
@@ -100,32 +160,81 @@ export function MarkdownRenderer({ content, className }: MarkdownRendererProps) 
                   fontFamily: 'monospace',
                   color: '#111827',
                   overflowX: 'auto',
+                  marginTop: 0,
                   marginBottom: '12px'
                 }
               }
             },
             ul: {
               props: {
-                className: "list-disc list-inside mb-3 space-y-1 ml-2"
+                style: listUlStyle
               }
             },
             ol: {
               props: {
-                className: "list-decimal list-inside mb-3 space-y-1 ml-2"
+                style: listOlStyle
               }
             },
             li: {
               props: {
-                className: "leading-relaxed"
+                style: listLiStyle
+              }
+            },
+            table: {
+              component: MarkdownTable
+            },
+            th: {
+              props: {
+                style: {
+                  border: '1px solid #e5e7eb',
+                  padding: '6px 8px',
+                  textAlign: 'left',
+                  backgroundColor: '#f9fafb',
+                  fontWeight: 600,
+                  color: 'inherit'
+                }
+              }
+            },
+            td: {
+              props: {
+                style: {
+                  border: '1px solid #e5e7eb',
+                  padding: '6px 8px',
+                  textAlign: 'left',
+                  verticalAlign: 'top',
+                  color: 'inherit'
+                }
+              }
+            },
+            tr: {
+              props: {
+                style: {
+                  backgroundColor: 'transparent'
+                }
+              }
+            },
+            thead: {
+              props: {
+                style: {
+                  backgroundColor: 'transparent'
+                }
+              }
+            },
+            tbody: {
+              props: {
+                style: {
+                  backgroundColor: 'transparent'
+                }
               }
             },
             blockquote: {
               props: {
                 style: {
                   borderLeft: '4px solid #93c5fd',
-                  paddingLeft: '16px',
                   padding: '8px',
+                  paddingLeft: '16px',
                   fontStyle: 'italic',
+                  marginTop: 0,
                   marginBottom: '12px',
                   backgroundColor: '#eff6ff',
                   borderRadius: '4px',
@@ -135,62 +244,32 @@ export function MarkdownRenderer({ content, className }: MarkdownRendererProps) 
             },
             h1: {
               props: {
-                style: {
-                  fontSize: '20px',
-                  fontWeight: 700,
-                  marginBottom: '12px',
-                  color: 'inherit'
-                }
+                style: headingMargin('20px')
               }
             },
             h2: {
               props: {
-                style: {
-                  fontSize: '18px',
-                  fontWeight: 700,
-                  marginBottom: '8px',
-                  color: 'inherit'
-                }
+                style: headingMargin('18px')
               }
             },
             h3: {
               props: {
-                style: {
-                  fontSize: '16px',
-                  fontWeight: 700,
-                  marginBottom: '8px',
-                  color: 'inherit'
-                }
+                style: headingMargin('16px')
               }
             },
             h4: {
               props: {
-                style: {
-                  fontSize: '14px',
-                  fontWeight: 700,
-                  marginBottom: '8px',
-                  color: 'inherit'
-                }
+                style: headingMargin('14px')
               }
             },
             h5: {
               props: {
-                style: {
-                  fontSize: '14px',
-                  fontWeight: 700,
-                  marginBottom: '8px',
-                  color: 'inherit'
-                }
+                style: headingMargin('14px')
               }
             },
             h6: {
               props: {
-                style: {
-                  fontSize: '14px',
-                  fontWeight: 700,
-                  marginBottom: '8px',
-                  color: 'inherit'
-                }
+                style: headingMargin('14px')
               }
             },
             hr: {
@@ -209,8 +288,8 @@ export function MarkdownRenderer({ content, className }: MarkdownRendererProps) 
                   color: '#2563eb',
                   textDecoration: 'underline'
                 },
-                target: "_blank",
-                rel: "noopener noreferrer"
+                target: '_blank',
+                rel: 'noopener noreferrer'
               }
             },
             img: {

--- a/src/components/ResizeHandle.tsx
+++ b/src/components/ResizeHandle.tsx
@@ -22,7 +22,7 @@ const ResizeHandleContainer = styled.div<{ $position: 'top' | 'bottom'; $isResiz
     background: #e5e7eb;
   }
 
-  @media (prefers-color-scheme: dark) {
+  [data-theme='dark'] & {
     &:hover {
       background: #4b5563;
     }
@@ -40,7 +40,7 @@ const ResizeHandleIndicator = styled.div<{ $position: 'top' | 'bottom' }>`
   border-radius: 2px;
   ${props => props.$position === 'top' ? 'top: 0;' : 'bottom: 0;'}
 
-  @media (prefers-color-scheme: dark) {
+  [data-theme='dark'] & {
     background: #6b7280;
   }
 `

--- a/src/components/styled/ChatComponents.tsx
+++ b/src/components/styled/ChatComponents.tsx
@@ -29,13 +29,6 @@ export const ChatWidget = styled.div`
     appearance: none;
   }
   
-  /* Try both media query approaches */
-  @media (prefers-color-scheme: dark) {
-    background-color: #1f2937;
-    border-color: #374151;
-  }
-  
-  /* Alternative approach using data attribute */
   &[data-theme="dark"] {
     background-color: #1f2937;
     border-color: #374151;
@@ -70,18 +63,6 @@ export const ChatMessage = styled.div<{ $isUser: boolean }>`
     color: inherit;
   }
   
-  /* Dark mode support - Media query */
-  @media (prefers-color-scheme: dark) {
-    background-color: ${props => props.$isUser ? '#3b82f6' : 'transparent'};
-    color: ${props => props.$isUser ? '#ffffff' : '#e5e7eb'};
-    
-    strong, b {
-      color: ${props => props.$isUser ? '#ffffff' : '#ffffff'};
-      font-weight: 700;
-    }
-  }
-  
-  /* Dark mode support - Data attribute (for ChatWindow/ChatWidget parents) */
   [data-theme="dark"] & {
     background-color: ${props => props.$isUser ? '#3b82f6' : 'transparent'};
     color: ${props => props.$isUser ? '#ffffff' : '#e5e7eb'};
@@ -119,15 +100,6 @@ export const ComposerShell = styled.div`
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
   }
 
-  @media (prefers-color-scheme: dark) {
-    background-color: #18181b;
-    border-color: rgba(255, 255, 255, 0.1);
-
-    &:focus-within {
-      border-color: rgba(255, 255, 255, 0.3);
-    }
-  }
-
   [data-theme='dark'] & {
     background-color: #18181b;
     border-color: rgba(255, 255, 255, 0.1);
@@ -147,11 +119,6 @@ export const ComposerToolbar = styled.div`
   padding: 8px 16px 10px;
   border-top: 1px solid #e5e7eb;
   background-color: #f9fafb;
-
-  @media (prefers-color-scheme: dark) {
-    border-top-color: #52525b;
-    background-color: #3f3f46;
-  }
 
   [data-theme='dark'] & {
     border-top-color: #52525b;
@@ -189,14 +156,6 @@ export const ComposerInnerInput = styled.textarea`
     cursor: not-allowed;
   }
 
-  @media (prefers-color-scheme: dark) {
-    color: #f9fafb;
-
-    &::placeholder {
-      color: #9ca3af;
-    }
-  }
-
   [data-theme='dark'] & {
     color: #f9fafb;
 
@@ -214,11 +173,6 @@ export const ChatInput = styled.div`
   padding: 10px 16px 12px;
   border-top: 1px solid #e5e7eb;
   background-color: #ffffff;
-  
-  @media (prefers-color-scheme: dark) {
-    background-color: #1f2937;
-    border-top-color: #374151;
-  }
   
   [data-theme="dark"] & {
     background-color: #1f2937;
@@ -256,21 +210,6 @@ export const ProfessionalInput = styled.textarea`
   &:disabled {
     opacity: 0.5;
     cursor: not-allowed;
-  }
-  
-  @media (prefers-color-scheme: dark) {
-    background-color: #374151;
-    color: #f9fafb;
-    border-color: #4b5563;
-    
-    &::placeholder {
-      color: #9ca3af;
-    }
-    
-    &:focus {
-      border-color: #3b82f6;
-      box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
-    }
   }
   
   [data-theme="dark"] & {
@@ -336,19 +275,6 @@ export const SendButton = styled.button`
     stroke: currentColor !important;
     fill: none !important;
     visibility: visible !important;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    border-color: #60a5fa;
-    color: #60a5fa;
-    &:hover:not(:disabled) {
-      background: #2563eb;
-      color: white;
-    }
-    &:disabled {
-      border-color: #6b7280;
-      color: #6b7280;
-    }
   }
 
   [data-theme="dark"] & {
@@ -419,26 +345,6 @@ export const ComposerSendButton = styled.button`
     stroke: currentColor !important;
     fill: none !important;
     visibility: visible !important;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    border-color: #60a5fa;
-    color: #60a5fa;
-
-    &:hover:not(:disabled) {
-      background: rgba(96, 165, 250, 0.14);
-      color: #93c5fd;
-      border-color: #93c5fd;
-    }
-
-    &:focus-visible {
-      box-shadow: 0 0 0 2px #18181b, 0 0 0 4px rgba(96, 165, 250, 0.45);
-    }
-
-    &:disabled {
-      border-color: #6b7280;
-      color: #6b7280;
-    }
   }
 
   [data-theme='dark'] & {
@@ -565,11 +471,6 @@ export const ChatWindow = styled.div<{ $position: string }>`
     }
   }}
   
-  @media (prefers-color-scheme: dark) {
-    background: #1f2937;
-    border-color: #374151;
-  }
-  
   &[data-theme="dark"] {
     background: #1f2937;
     border-color: #374151;
@@ -664,20 +565,6 @@ export const Conversation = styled.div`
     background: #94a3b8;
   }
   
-  @media (prefers-color-scheme: dark) {
-    &::-webkit-scrollbar-track {
-      background: #374151;
-    }
-    
-    &::-webkit-scrollbar-thumb {
-      background: #6b7280;
-    }
-    
-    &::-webkit-scrollbar-thumb:hover {
-      background: #9ca3af;
-    }
-  }
-  
   [data-theme="dark"] & {
     &::-webkit-scrollbar-track {
       background: #374151;
@@ -720,7 +607,7 @@ export const LoadingDots = styled.div`
     }
   }
   
-  @media (prefers-color-scheme: dark) {
+  [data-theme="dark"] & {
     .dot {
       background: #9ca3af;
     }
@@ -732,10 +619,6 @@ export const Timestamp = styled.div<{ $isUser: boolean }>`
   font-size: 12px;
   margin-top: 4px;
   color: ${props => props.$isUser ? 'rgba(255, 255, 255, 0.8)' : '#6b7280'};
-  
-  @media (prefers-color-scheme: dark) {
-    color: ${props => props.$isUser ? 'rgba(255, 255, 255, 0.8)' : '#d1d5db'};
-  }
   
   [data-theme="dark"] & {
     color: ${props => props.$isUser ? 'rgba(255, 255, 255, 0.8)' : '#d1d5db'};
@@ -750,7 +633,7 @@ export const ErrorMessage = styled.div`
   padding: 8px;
   margin: 16px 0;
   
-  @media (prefers-color-scheme: dark) {
+  [data-theme="dark"] & {
     color: #f87171;
   }
 `
@@ -773,7 +656,7 @@ export const ResizeHandle = styled.div<{ $position: string }>`
     background: linear-gradient(90deg, #3b82f6 0%, #1d4ed8 50%, #3b82f6 100%);
   }
   
-  @media (prefers-color-scheme: dark) {
+  [data-theme="dark"] & {
     background: linear-gradient(90deg, #374151 0%, #3b82f6 50%, #374151 100%);
     
     &:hover {
@@ -815,15 +698,6 @@ export const WelcomeScreenContainer = styled.div<{ $primaryColor?: string }>`
     return '#ffffff'
   }};
   
-  @media (prefers-color-scheme: dark) {
-    background: ${props => {
-      if (props.$primaryColor) {
-        return `linear-gradient(to bottom, ${props.$primaryColor} 0%, ${props.$primaryColor} 20%, rgba(31, 41, 55, 0.3) 45%, rgba(31, 41, 55, 0.7) 65%, rgba(31, 41, 55, 1) 100%)`
-      }
-      return '#1f2937'
-    }};
-  }
-  
   [data-theme="dark"] & {
     background: ${props => {
       if (props.$primaryColor) {
@@ -850,10 +724,6 @@ export const WelcomeGreeting = styled.div`
   text-align: center;
   color: #111827;
   margin-bottom: 8px;
-  
-  @media (prefers-color-scheme: dark) {
-    color: #f9fafb;
-  }
   
   [data-theme="dark"] & {
     color: #f9fafb;
@@ -917,17 +787,6 @@ export const QuestionButton = styled.button<{ $primaryColor?: string }>`
     cursor: not-allowed;
   }
   
-  @media (prefers-color-scheme: dark) {
-    background-color: #374151;
-    color: #f9fafb;
-    border-color: #4b5563;
-    
-    &:hover:not(:disabled) {
-      background-color: ${props => props.$primaryColor ? `${props.$primaryColor}25` : '#4b5563'};
-      border-color: ${props => props.$primaryColor || '#6b7280'};
-    }
-  }
-  
   [data-theme="dark"] & {
     background-color: #374151;
     color: #f9fafb;
@@ -949,10 +808,6 @@ export const WelcomeInputContainer = styled.div`
   margin-top: auto;
   padding-top: 16px;
   border-top: 1px solid #e5e7eb;
-  
-  @media (prefers-color-scheme: dark) {
-    border-top-color: #374151;
-  }
   
   [data-theme="dark"] & {
     border-top-color: #374151;


### PR DESCRIPTION
## Chat Widget PR: Dark Mode Unification & Markdown Rendering

### Overview
Comprehensive refactor of dark mode theming across the chat widget, eliminating inconsistencies between `prefers-color-scheme` media queries and `[data-theme]` attribute selectors. Also significantly improves markdown rendering with proper table support and consistent spacing.

### Key Changes

#### Theme System Refactor
- **Unified Theme Detection**
  - Added `useEffect` hook in `InlineChat.tsx` to properly handle `theme` prop values (`'light'`, `'dark'`, `'auto'`)
  - Migrated all dark mode styles from `@media (prefers-color-scheme: dark)` to `[data-theme="dark"]` attribute selectors
  - Eliminated duplicate and conflicting style rules across 9 components

- **Affected Components**
  - `AttachmentPicker.tsx` - Removed redundant media queries
  - `ChatHeader.tsx` - Consolidated dark mode styling
  - `Conversation.tsx` - Fixed scrollbar colors and scroll button styling
  - `ResizeHandle.tsx` - Updated resize handle dark mode
  - `ChatComponents.tsx` - Major cleanup of duplicate dark mode rules (148 lines removed)
  - `InlineChat.tsx` - Added proper theme state management

#### Markdown Rendering Improvements
- **Table Support**
  - Added `MarkdownTable` component with horizontal scroll for wide tables
  - Implemented proper `thead`, `tbody`, `th`, `td` styling
  - Added dark mode table border colors (`#4b5563`) and header backgrounds (`#374151`)

- **Spacing & Layout**
  - Standardized list styling with proper `marginBottom`, `paddingLeft`, and `lineHeight`
  - Added `headingMargin` helper for consistent heading spacing
  - Fixed blockquote dark mode colors (blue theme: `#1e3a8a` background, `#3b82f6` border)
  - Improved code block dark mode contrast

- **Removed Tailwind Classes**
  - Replaced Tailwind utility classes (`list-disc list-inside mb-3 space-y-1 ml-2`) with explicit React.CSSProperties for better reliability

### Example Flow

1. Widget receives `theme` prop: `'auto'`, `'light'`, or `'dark'`
2. If `'auto'`, widget listens to system preference changes via `window.matchMedia`
3. Widget sets `data-theme` attribute on root element based on resolved theme
4. All styled components use `[data-theme="dark"] &` selector for dark mode styles
5. Markdown content inherits theme colors automatically

### Migration/Deployment Notes

- **Breaking Change**: Removed all `@media (prefers-color-scheme: dark)` rules - widget now strictly follows `theme` prop or system preference when `'auto'`
- Ensure widget consumers are passing `theme` prop correctly (if not using default `'auto'`)
- No database migrations required

### Testing

- Tested theme switching: `light`, `dark`, and `auto` (system preference)
- Verified markdown tables render correctly on both themes
- Confirmed no style conflicts between old media queries and new attribute selectors
- Tested scrollbar colors, resize handles, and attachment picker in dark mode

### Code Health
- Removed 272 lines of code, added 196 lines (net -76 lines)
- Eliminated all `prefers-color-scheme` media queries for consistent theme behavior

---

**Closes:** AD-623 