### PR TITLE
Fix/ad 623 improve user message attachment chip readability

### DIFF
--- a/src/components/AttachmentChips.tsx
+++ b/src/components/AttachmentChips.tsx
@@ -1,6 +1,8 @@
 import { AttachmentItem } from '@/types'
 import { FileText, Image as ImageIcon, X } from 'lucide-react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
+
+export type AttachmentChipsTone = 'default' | 'onPrimary'
 
 const Row = styled.div`
   display: flex;
@@ -9,23 +11,42 @@ const Row = styled.div`
   margin-bottom: 6px;
 `
 
-const Chip = styled.div<{ $isImage?: boolean }>`
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  max-width: 220px;
-  padding: 4px 8px;
-  border-radius: 8px;
-  font-size: 12px;
-  background: ${(p) => (p.$isImage ? 'rgba(59, 130, 246, 0.12)' : 'rgba(107, 114, 128, 0.12)')};
+const defaultChipStyles = css<{ $isImage?: boolean }>`
+  background: ${(p) =>
+    p.$isImage ? 'rgba(59, 130, 246, 0.12)' : 'rgba(107, 114, 128, 0.12)'};
   color: #374151;
   border: 1px solid #e5e7eb;
 
   [data-theme='dark'] & {
     color: #e5e7eb;
     border-color: #4b5563;
-    background: ${(p) => (p.$isImage ? 'rgba(59, 130, 246, 0.2)' : 'rgba(107, 114, 128, 0.25)')};
+    background: ${(p) =>
+      p.$isImage ? 'rgba(59, 130, 246, 0.2)' : 'rgba(107, 114, 128, 0.25)'};
   }
+`
+
+const onPrimaryChipStyles = css<{ $isImage?: boolean }>`
+  background: ${(p) =>
+    p.$isImage ? 'rgba(255, 255, 255, 0.22)' : 'rgba(255, 255, 255, 0.16)'};
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+`
+
+const Chip = styled.div<{ $isImage?: boolean; $tone: AttachmentChipsTone }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 220px;
+  padding: 5px 10px;
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.3;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+
+  ${(p) => (p.$tone === 'onPrimary' ? onPrimaryChipStyles : defaultChipStyles)}
 `
 
 const Thumb = styled.img`
@@ -33,6 +54,7 @@ const Thumb = styled.img`
   height: 28px;
   object-fit: cover;
   border-radius: 4px;
+  flex-shrink: 0;
 `
 
 const Name = styled.span`
@@ -43,16 +65,8 @@ const Name = styled.span`
   min-width: 0;
 `
 
-const RemoveBtn = styled.button`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2px;
-  border: none;
-  background: transparent;
-  cursor: pointer;
+const defaultRemoveStyles = css`
   color: #6b7280;
-  border-radius: 4px;
 
   &:hover {
     color: #ef4444;
@@ -60,13 +74,46 @@ const RemoveBtn = styled.button`
   }
 `
 
+const onPrimaryRemoveStyles = css`
+  color: rgba(255, 255, 255, 0.85);
+
+  &:hover {
+    color: #ffffff;
+    background: rgba(255, 255, 255, 0.2);
+  }
+`
+
+const RemoveBtn = styled.button<{ $tone: AttachmentChipsTone }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 4px;
+  transition:
+    color 0.2s ease,
+    background-color 0.2s ease;
+
+  ${(p) =>
+    p.$tone === 'onPrimary' ? onPrimaryRemoveStyles : defaultRemoveStyles}
+`
+
 interface AttachmentChipsProps {
   attachments: AttachmentItem[]
   onRemove?: (id: string) => void
   readOnly?: boolean
+  /** Use onPrimary inside user message bubbles (colored background). */
+  tone?: AttachmentChipsTone
 }
 
-export function AttachmentChips({ attachments, onRemove, readOnly }: AttachmentChipsProps) {
+export function AttachmentChips({
+  attachments,
+  onRemove,
+  readOnly,
+  tone = 'default',
+}: AttachmentChipsProps) {
   if (!attachments.length) return null
 
   return (
@@ -75,9 +122,14 @@ export function AttachmentChips({ attachments, onRemove, readOnly }: AttachmentC
         const isImage = a.type === 'image'
         const showThumb = isImage && (a.preview || a.url)
         return (
-          <Chip key={a.id} $isImage={isImage} title={a.name}>
+          <Chip key={a.id} $isImage={isImage} $tone={tone} title={a.name}>
             {showThumb ? (
-              <Thumb src={a.preview || a.url} alt="" loading="lazy" decoding="async" />
+              <Thumb
+                src={a.preview || a.url}
+                alt=""
+                loading="lazy"
+                decoding="async"
+              />
             ) : isImage ? (
               <ImageIcon size={16} aria-hidden />
             ) : (
@@ -85,7 +137,12 @@ export function AttachmentChips({ attachments, onRemove, readOnly }: AttachmentC
             )}
             <Name>{a.name}</Name>
             {!readOnly && onRemove && (
-              <RemoveBtn type="button" onClick={() => onRemove(a.id)} aria-label={`Remove ${a.name}`}>
+              <RemoveBtn
+                type="button"
+                $tone={tone}
+                onClick={() => onRemove(a.id)}
+                aria-label={`Remove ${a.name}`}
+              >
                 <X size={14} />
               </RemoveBtn>
             )}

--- a/src/components/EmbeddedChat.tsx
+++ b/src/components/EmbeddedChat.tsx
@@ -20,7 +20,7 @@ import {
   ComposerToolbar,
   ErrorMessage,
   ComposerSendButton,
-  LoadingDots
+  LoadingDots,
 } from './styled/ChatComponents'
 
 interface EmbeddedChatProps {
@@ -36,7 +36,7 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
     exportMessagePdf,
     isLoading,
     error,
-    hasSessionStarted
+    hasSessionStarted,
   } = chat
   const [inputValue, setInputValue] = React.useState('')
   const [isDarkMode, setIsDarkMode] = React.useState(false)
@@ -53,7 +53,7 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
     clearStaged,
     maxFiles,
     maxBytes,
-    allowed
+    allowed,
   } = useWidgetAttachmentStaging(config, uploadAttachment)
 
   const getThemeValue = () => {
@@ -82,7 +82,11 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
     const trimmed = inputValue.trim()
     if ((!trimmed && stagedAttachments.length === 0) || isLoading) return
 
-    await sendMessage(trimmed, undefined, stagedAttachments.length ? stagedAttachments : undefined)
+    await sendMessage(
+      trimmed,
+      undefined,
+      stagedAttachments.length ? stagedAttachments : undefined
+    )
     setInputValue('')
     clearStaged()
 
@@ -106,14 +110,14 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
         minHeight: 0,
         display: 'flex',
         flexDirection: 'column' as const,
-        borderRadius: '8px'
+        borderRadius: '8px',
       }
     }
     return {
       height: config.height,
       display: 'flex',
       flexDirection: 'column' as const,
-      borderRadius: '8px'
+      borderRadius: '8px',
     }
   }, [config.height])
 
@@ -135,7 +139,9 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
       data-theme={getThemeValue()}
       style={{
         ...heightStyle,
-        ...(config.backgroundColor ? { backgroundColor: config.backgroundColor } : {}),
+        ...(config.backgroundColor
+          ? { backgroundColor: config.backgroundColor }
+          : {}),
         ...(config.textColor ? { color: config.textColor } : {}),
         ...(config.borderRadius != null && config.borderRadius !== ''
           ? { borderRadius: config.borderRadius }
@@ -143,7 +149,9 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
       }}
     >
       {/* Welcome screen or chat messages */}
-      {config.quickQuestions && config.quickQuestions.length > 0 && !hasSessionStarted ? (
+      {config.quickQuestions &&
+      config.quickQuestions.length > 0 &&
+      !hasSessionStarted ? (
         <WelcomeScreen
           config={config}
           onQuestionClick={async (question) => {
@@ -161,21 +169,22 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
             onDrop={onDrop}
           >
             <ConversationContent>
-              {messages.map(message => (
+              {messages.map((message) => (
                 <div
                   key={message.id}
                   style={{
                     display: 'flex',
                     marginBottom: '16px',
-                    justifyContent: message.role === 'user' ? 'flex-end' : 'flex-start',
+                    justifyContent:
+                      message.role === 'user' ? 'flex-end' : 'flex-start',
                     alignItems: 'flex-start',
-                    gap: '8px'
+                    gap: '8px',
                   }}
                 >
                   {message.role === 'assistant' && config.agentImage && (
                     <AgentAvatar
                       src={config.agentImage}
-                      alt={config.chatName || "Agent"}
+                      alt={config.chatName || 'Agent'}
                       $size="28px"
                     />
                   )}
@@ -185,13 +194,17 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
                         display: 'flex',
                         flexDirection: 'column',
                         alignItems: 'flex-start',
-                        maxWidth: '80%'
+                        maxWidth: '80%',
                       }}
                     >
                       <ChatMessage $isUser={false}>
                         <AssistantMessageContent message={message} />
                       </ChatMessage>
-                      {shouldShowAssistantActions(message, messages, isLoading) && (
+                      {shouldShowAssistantActions(
+                        message,
+                        messages,
+                        isLoading
+                      ) && (
                         <AssistantMessageActions
                           content={message.content}
                           disabled={isLoading}
@@ -202,9 +215,14 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
                   ) : (
                     <ChatMessage $isUser={true}>
                       <>
-                        {message.attachments && message.attachments.length > 0 && (
-                          <AttachmentChips attachments={message.attachments} readOnly />
-                        )}
+                        {message.attachments &&
+                          message.attachments.length > 0 && (
+                            <AttachmentChips
+                              attachments={message.attachments}
+                              readOnly
+                              tone="onPrimary"
+                            />
+                          )}
                         {message.content ? message.content : null}
                       </>
                     </ChatMessage>
@@ -212,42 +230,56 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
                 </div>
               ))}
 
-          {isLoading && (
-            <div style={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'flex-start', gap: '8px', marginBottom: '16px' }}>
-              {config.agentImage && (
-                <AgentAvatar
-                  src={config.agentImage}
-                  alt={config.chatName || "Agent"}
-                  $size="28px"
-                />
+              {isLoading && (
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'flex-start',
+                    alignItems: 'flex-start',
+                    gap: '8px',
+                    marginBottom: '16px',
+                  }}
+                >
+                  {config.agentImage && (
+                    <AgentAvatar
+                      src={config.agentImage}
+                      alt={config.chatName || 'Agent'}
+                      $size="28px"
+                    />
+                  )}
+                  <ChatMessage $isUser={false}>
+                    <LoadingDots>
+                      <div className="dot"></div>
+                      <div className="dot"></div>
+                      <div className="dot"></div>
+                    </LoadingDots>
+                  </ChatMessage>
+                </div>
               )}
-              <ChatMessage $isUser={false}>
-                <LoadingDots>
-                  <div className="dot"></div>
-                  <div className="dot"></div>
-                  <div className="dot"></div>
-                </LoadingDots>
-              </ChatMessage>
-            </div>
-          )}
 
-              {error && (
-                <ErrorMessage>
-                  {error}
-                </ErrorMessage>
-              )}
+              {error && <ErrorMessage>{error}</ErrorMessage>}
             </ConversationContent>
           </Conversation>
 
           {/* Chat input */}
-          <ChatInput style={{ flexDirection: 'column', alignItems: 'stretch', gap: 0 }}>
-            {(attachmentError || (attachmentsEnabled && stagedAttachments.length > 0)) && (
+          <ChatInput
+            style={{ flexDirection: 'column', alignItems: 'stretch', gap: 0 }}
+          >
+            {(attachmentError ||
+              (attachmentsEnabled && stagedAttachments.length > 0)) && (
               <div style={{ paddingBottom: 8 }}>
                 {attachmentError && (
-                  <div style={{ fontSize: 12, color: '#dc2626', marginBottom: 4 }}>{attachmentError}</div>
+                  <div
+                    style={{ fontSize: 12, color: '#dc2626', marginBottom: 4 }}
+                  >
+                    {attachmentError}
+                  </div>
                 )}
                 {attachmentsEnabled && stagedAttachments.length > 0 && (
-                  <AttachmentChips attachments={stagedAttachments} onRemove={removeStaged} />
+                  <AttachmentChips
+                    attachments={stagedAttachments}
+                    onRemove={removeStaged}
+                  />
                 )}
               </div>
             )}
@@ -263,7 +295,15 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
                   disabled={isLoading}
                 />
                 <ComposerToolbar>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, minWidth: 0 }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 8,
+                      flex: 1,
+                      minWidth: 0,
+                    }}
+                  >
                     {attachmentsEnabled && (
                       <AttachmentPicker
                         integrated
@@ -281,7 +321,10 @@ export function EmbeddedChat({ config, chat }: EmbeddedChatProps) {
                   <ComposerSendButton
                     type="button"
                     onClick={handleSendMessage}
-                    disabled={isLoading || (!inputValue.trim() && stagedAttachments.length === 0)}
+                    disabled={
+                      isLoading ||
+                      (!inputValue.trim() && stagedAttachments.length === 0)
+                    }
                     aria-label="Send message"
                   >
                     <SendIcon size={13} />

--- a/src/components/FloatingChat.tsx
+++ b/src/components/FloatingChat.tsx
@@ -24,7 +24,7 @@ import {
   FloatingButton,
   ComposerSendButton,
   LoadingDots,
-  ResizeHandle as StyledResizeHandle
+  ResizeHandle as StyledResizeHandle,
 } from './styled/ChatComponents'
 
 interface FloatingChatProps {
@@ -42,10 +42,12 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
     error,
     isOpen,
     setIsOpen,
-    hasSessionStarted
+    hasSessionStarted,
   } = chat
   const [inputValue, setInputValue] = React.useState('')
-  const [chatHeight, setChatHeight] = React.useState<number | string>(config.height || 600)
+  const [chatHeight, setChatHeight] = React.useState<number | string>(
+    config.height || 600
+  )
   const [isDarkMode, setIsDarkMode] = React.useState(false)
   const inputRef = React.useRef<HTMLTextAreaElement>(null)
 
@@ -60,7 +62,7 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
     clearStaged,
     maxFiles,
     maxBytes,
-    allowed
+    allowed,
   } = useWidgetAttachmentStaging(config, uploadAttachment)
 
   const getThemeValue = () => {
@@ -74,11 +76,11 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
       const checkDarkMode = () => {
         setIsDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches)
       }
-      
+
       checkDarkMode()
       const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
       mediaQuery.addEventListener('change', checkDarkMode)
-      
+
       return () => mediaQuery.removeEventListener('change', checkDarkMode)
     } else {
       setIsDarkMode(config.theme === 'dark')
@@ -89,7 +91,11 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
     const trimmed = inputValue.trim()
     if ((!trimmed && stagedAttachments.length === 0) || isLoading) return
 
-    await sendMessage(trimmed, undefined, stagedAttachments.length ? stagedAttachments : undefined)
+    await sendMessage(
+      trimmed,
+      undefined,
+      stagedAttachments.length ? stagedAttachments : undefined
+    )
     setInputValue('')
     clearStaged()
 
@@ -131,9 +137,7 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
         <div className="icon-container">
           <MessageSquareIcon size={16} />
         </div>
-        <span>
-          {config.buttonText || config.chatName || "AI Chat"}
-        </span>
+        <span>{config.buttonText || config.chatName || 'AI Chat'}</span>
       </FloatingButton>
     )
   }
@@ -144,9 +148,11 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
       data-theme={getThemeValue()}
       style={{
         height: chatHeight,
-        ...(config.backgroundColor ? { backgroundColor: config.backgroundColor } : {}),
+        ...(config.backgroundColor
+          ? { backgroundColor: config.backgroundColor }
+          : {}),
         ...(config.textColor ? { color: config.textColor } : {}),
-        ...config.chatWindowStyle
+        ...config.chatWindowStyle,
       }}
     >
       {/* Resize handle at top */}
@@ -156,7 +162,8 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
           onMouseDown={(e) => {
             e.preventDefault()
             const startY = e.clientY
-            const startHeight = typeof chatHeight === 'number' ? chatHeight : 600
+            const startHeight =
+              typeof chatHeight === 'number' ? chatHeight : 600
 
             const handleMouseMove = (e: MouseEvent) => {
               const deltaY = e.clientY - startY
@@ -182,12 +189,18 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
           chatName={config.chatName}
           onClose={() => setIsOpen(false)}
           primaryColor={config.primaryColor}
-          showWelcomeScreen={config.quickQuestions && config.quickQuestions.length > 0 && !hasSessionStarted}
+          showWelcomeScreen={
+            config.quickQuestions &&
+            config.quickQuestions.length > 0 &&
+            !hasSessionStarted
+          }
         />
       )}
 
       {/* Welcome screen or chat messages */}
-      {config.quickQuestions && config.quickQuestions.length > 0 && !hasSessionStarted ? (
+      {config.quickQuestions &&
+      config.quickQuestions.length > 0 &&
+      !hasSessionStarted ? (
         <WelcomeScreen
           config={config}
           onQuestionClick={async (question) => {
@@ -198,23 +211,28 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
         />
       ) : (
         <>
-          <Conversation surfaceTheme={getThemeValue()} onDragOver={onDragOver} onDrop={onDrop}>
+          <Conversation
+            surfaceTheme={getThemeValue()}
+            onDragOver={onDragOver}
+            onDrop={onDrop}
+          >
             <ConversationContent>
-              {messages.map(message => (
+              {messages.map((message) => (
                 <div
                   key={message.id}
                   style={{
                     display: 'flex',
                     marginBottom: '16px',
-                    justifyContent: message.role === 'user' ? 'flex-end' : 'flex-start',
+                    justifyContent:
+                      message.role === 'user' ? 'flex-end' : 'flex-start',
                     alignItems: 'flex-start',
-                    gap: '8px'
+                    gap: '8px',
                   }}
                 >
                   {message.role === 'assistant' && config.agentImage && (
                     <AgentAvatar
                       src={config.agentImage}
-                      alt={config.chatName || "Agent"}
+                      alt={config.chatName || 'Agent'}
                       $size="28px"
                     />
                   )}
@@ -224,13 +242,17 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
                         display: 'flex',
                         flexDirection: 'column',
                         alignItems: 'flex-start',
-                        maxWidth: '80%'
+                        maxWidth: '80%',
                       }}
                     >
                       <ChatMessage $isUser={false}>
                         <AssistantMessageContent message={message} />
                       </ChatMessage>
-                      {shouldShowAssistantActions(message, messages, isLoading) && (
+                      {shouldShowAssistantActions(
+                        message,
+                        messages,
+                        isLoading
+                      ) && (
                         <AssistantMessageActions
                           content={message.content}
                           disabled={isLoading}
@@ -241,9 +263,14 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
                   ) : (
                     <ChatMessage $isUser={true}>
                       <>
-                        {message.attachments && message.attachments.length > 0 && (
-                          <AttachmentChips attachments={message.attachments} readOnly />
-                        )}
+                        {message.attachments &&
+                          message.attachments.length > 0 && (
+                            <AttachmentChips
+                              attachments={message.attachments}
+                              readOnly
+                              tone="onPrimary"
+                            />
+                          )}
                         {message.content ? message.content : null}
                       </>
                     </ChatMessage>
@@ -252,15 +279,23 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
               ))}
 
               {isLoading && (
-                <div style={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'flex-start', gap: '8px', marginBottom: '16px' }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'flex-start',
+                    alignItems: 'flex-start',
+                    gap: '8px',
+                    marginBottom: '16px',
+                  }}
+                >
                   {config.agentImage && (
                     <AgentAvatar
                       src={config.agentImage}
-                      alt={config.chatName || "Agent"}
+                      alt={config.chatName || 'Agent'}
                       $size="28px"
                     />
                   )}
-                   <ChatMessage $isUser={false}>
+                  <ChatMessage $isUser={false}>
                     <LoadingDots>
                       <div className="dot"></div>
                       <div className="dot"></div>
@@ -270,23 +305,29 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
                 </div>
               )}
 
-              {error && (
-                <ErrorMessage>
-                  {error}
-                </ErrorMessage>
-              )}
+              {error && <ErrorMessage>{error}</ErrorMessage>}
             </ConversationContent>
           </Conversation>
 
           {/* Chat input - Full width */}
-          <ChatInput style={{ flexDirection: 'column', alignItems: 'stretch', gap: 0 }}>
-            {(attachmentError || (attachmentsEnabled && stagedAttachments.length > 0)) && (
+          <ChatInput
+            style={{ flexDirection: 'column', alignItems: 'stretch', gap: 0 }}
+          >
+            {(attachmentError ||
+              (attachmentsEnabled && stagedAttachments.length > 0)) && (
               <div style={{ paddingBottom: 8 }}>
                 {attachmentError && (
-                  <div style={{ fontSize: 12, color: '#dc2626', marginBottom: 4 }}>{attachmentError}</div>
+                  <div
+                    style={{ fontSize: 12, color: '#dc2626', marginBottom: 4 }}
+                  >
+                    {attachmentError}
+                  </div>
                 )}
                 {attachmentsEnabled && stagedAttachments.length > 0 && (
-                  <AttachmentChips attachments={stagedAttachments} onRemove={removeStaged} />
+                  <AttachmentChips
+                    attachments={stagedAttachments}
+                    onRemove={removeStaged}
+                  />
                 )}
               </div>
             )}
@@ -302,7 +343,15 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
                   disabled={isLoading}
                 />
                 <ComposerToolbar>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, minWidth: 0 }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 8,
+                      flex: 1,
+                      minWidth: 0,
+                    }}
+                  >
                     {attachmentsEnabled && (
                       <AttachmentPicker
                         integrated
@@ -320,7 +369,10 @@ export function FloatingChat({ config, chat }: FloatingChatProps) {
                   <ComposerSendButton
                     type="button"
                     onClick={handleSendMessage}
-                    disabled={isLoading || (!inputValue.trim() && stagedAttachments.length === 0)}
+                    disabled={
+                      isLoading ||
+                      (!inputValue.trim() && stagedAttachments.length === 0)
+                    }
                     aria-label="Send message"
                   >
                     <SendIcon size={13} />

--- a/src/components/InlineChat.tsx
+++ b/src/components/InlineChat.tsx
@@ -18,7 +18,7 @@ import {
   ComposerToolbar,
   ErrorMessage,
   ComposerSendButton,
-  LoadingDots
+  LoadingDots,
 } from './styled/ChatComponents'
 
 interface InlineChatProps {
@@ -27,7 +27,14 @@ interface InlineChatProps {
 }
 
 export function InlineChat({ config, chat }: InlineChatProps) {
-  const { messages, sendMessage, uploadAttachment, isLoading, error, hasSessionStarted } = chat
+  const {
+    messages,
+    sendMessage,
+    uploadAttachment,
+    isLoading,
+    error,
+    hasSessionStarted,
+  } = chat
   const [inputValue, setInputValue] = React.useState('')
   const inputRef = React.useRef<HTMLTextAreaElement>(null)
 
@@ -42,14 +49,18 @@ export function InlineChat({ config, chat }: InlineChatProps) {
     clearStaged,
     maxFiles,
     maxBytes,
-    allowed
+    allowed,
   } = useWidgetAttachmentStaging(config, uploadAttachment)
 
   const handleSendMessage = async () => {
     const trimmed = inputValue.trim()
     if ((!trimmed && stagedAttachments.length === 0) || isLoading) return
 
-    await sendMessage(trimmed, undefined, stagedAttachments.length ? stagedAttachments : undefined)
+    await sendMessage(
+      trimmed,
+      undefined,
+      stagedAttachments.length ? stagedAttachments : undefined
+    )
     setInputValue('')
     clearStaged()
 
@@ -88,11 +99,13 @@ export function InlineChat({ config, chat }: InlineChatProps) {
         flexDirection: 'column',
         backgroundColor: 'white',
         border: '1px solid #e5e7eb',
-        borderRadius: '8px'
+        borderRadius: '8px',
       }}
     >
       {/* Welcome screen or chat messages */}
-      {config.quickQuestions && config.quickQuestions.length > 0 && !hasSessionStarted ? (
+      {config.quickQuestions &&
+      config.quickQuestions.length > 0 &&
+      !hasSessionStarted ? (
         <WelcomeScreen
           config={config}
           onQuestionClick={async (question) => {
@@ -103,23 +116,29 @@ export function InlineChat({ config, chat }: InlineChatProps) {
         />
       ) : (
         <>
-          <Conversation style={{ flex: 1 }} surfaceTheme="light" onDragOver={onDragOver} onDrop={onDrop}>
+          <Conversation
+            style={{ flex: 1 }}
+            surfaceTheme="light"
+            onDragOver={onDragOver}
+            onDrop={onDrop}
+          >
             <ConversationContent>
-              {messages.map(message => (
+              {messages.map((message) => (
                 <div
                   key={message.id}
                   style={{
                     display: 'flex',
                     marginBottom: '12px',
-                    justifyContent: message.role === 'user' ? 'flex-end' : 'flex-start',
+                    justifyContent:
+                      message.role === 'user' ? 'flex-end' : 'flex-start',
                     alignItems: 'flex-start',
-                    gap: '8px'
+                    gap: '8px',
                   }}
                 >
                   {message.role === 'assistant' && config.agentImage && (
                     <AgentAvatar
                       src={config.agentImage}
-                      alt={config.chatName || "Agent"}
+                      alt={config.chatName || 'Agent'}
                       $size="28px"
                     />
                   )}
@@ -128,9 +147,14 @@ export function InlineChat({ config, chat }: InlineChatProps) {
                       <AssistantMessageContent message={message} />
                     ) : (
                       <>
-                        {message.attachments && message.attachments.length > 0 && (
-                          <AttachmentChips attachments={message.attachments} readOnly />
-                        )}
+                        {message.attachments &&
+                          message.attachments.length > 0 && (
+                            <AttachmentChips
+                              attachments={message.attachments}
+                              readOnly
+                              tone="onPrimary"
+                            />
+                          )}
                         {message.content ? message.content : null}
                       </>
                     )}
@@ -138,42 +162,56 @@ export function InlineChat({ config, chat }: InlineChatProps) {
                 </div>
               ))}
 
-          {isLoading && (
-            <div style={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'flex-start', gap: '8px', marginBottom: '12px' }}>
-              {config.agentImage && (
-                <AgentAvatar
-                  src={config.agentImage}
-                  alt={config.chatName || "Agent"}
-                  $size="28px"
-                />
+              {isLoading && (
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'flex-start',
+                    alignItems: 'flex-start',
+                    gap: '8px',
+                    marginBottom: '12px',
+                  }}
+                >
+                  {config.agentImage && (
+                    <AgentAvatar
+                      src={config.agentImage}
+                      alt={config.chatName || 'Agent'}
+                      $size="28px"
+                    />
+                  )}
+                  <ChatMessage $isUser={false}>
+                    <LoadingDots>
+                      <div className="dot"></div>
+                      <div className="dot"></div>
+                      <div className="dot"></div>
+                    </LoadingDots>
+                  </ChatMessage>
+                </div>
               )}
-              <ChatMessage $isUser={false}>
-                <LoadingDots>
-                  <div className="dot"></div>
-                  <div className="dot"></div>
-                  <div className="dot"></div>
-                </LoadingDots>
-              </ChatMessage>
-            </div>
-          )}
 
-              {error && (
-                <ErrorMessage>
-                  {error}
-                </ErrorMessage>
-              )}
+              {error && <ErrorMessage>{error}</ErrorMessage>}
             </ConversationContent>
           </Conversation>
 
           {/* Chat input */}
-          <ChatInput style={{ flexDirection: 'column', alignItems: 'stretch', gap: 0 }}>
-            {(attachmentError || (attachmentsEnabled && stagedAttachments.length > 0)) && (
+          <ChatInput
+            style={{ flexDirection: 'column', alignItems: 'stretch', gap: 0 }}
+          >
+            {(attachmentError ||
+              (attachmentsEnabled && stagedAttachments.length > 0)) && (
               <div style={{ paddingBottom: 8 }}>
                 {attachmentError && (
-                  <div style={{ fontSize: 12, color: '#dc2626', marginBottom: 4 }}>{attachmentError}</div>
+                  <div
+                    style={{ fontSize: 12, color: '#dc2626', marginBottom: 4 }}
+                  >
+                    {attachmentError}
+                  </div>
                 )}
                 {attachmentsEnabled && stagedAttachments.length > 0 && (
-                  <AttachmentChips attachments={stagedAttachments} onRemove={removeStaged} />
+                  <AttachmentChips
+                    attachments={stagedAttachments}
+                    onRemove={removeStaged}
+                  />
                 )}
               </div>
             )}
@@ -189,7 +227,15 @@ export function InlineChat({ config, chat }: InlineChatProps) {
                   disabled={isLoading}
                 />
                 <ComposerToolbar>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, minWidth: 0 }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 8,
+                      flex: 1,
+                      minWidth: 0,
+                    }}
+                  >
                     {attachmentsEnabled && (
                       <AttachmentPicker
                         integrated
@@ -207,7 +253,10 @@ export function InlineChat({ config, chat }: InlineChatProps) {
                   <ComposerSendButton
                     type="button"
                     onClick={handleSendMessage}
-                    disabled={isLoading || (!inputValue.trim() && stagedAttachments.length === 0)}
+                    disabled={
+                      isLoading ||
+                      (!inputValue.trim() && stagedAttachments.length === 0)
+                    }
                     aria-label="Send message"
                   >
                     <SendIcon size={13} />


### PR DESCRIPTION
## Summary
- Add `tone` prop to `AttachmentChips` (`default` | `onPrimary`) so file attachment pills on user bubbles use high-contrast styling (white text, frosted white background, visible border) instead of gray-on-blue.
- Pass `tone="onPrimary"` for user message attachments in `InlineChat`, `FloatingChat`, and `EmbeddedChat`.
- Composer staging and assistant attachment chips keep `default` styling for light backgrounds.

## Problem
On the blue user message bubble (`#3b82f6`), attachment chips used gray text on a light gray pill, which was difficult to read against the primary-colored background.

## Test plan
- [ ] Send a user message with a document attachment in floating, embedded, and inline modes; confirm chip text and icon are white and readable on the blue bubble.
- [ ] Confirm staged attachments in the composer still use gray chips on the input area.
- [ ] Confirm assistant non-image attachment chips on gray bubbles are unchanged.
- [ ] `npm run type-check` and `npm run test -- --run`